### PR TITLE
FileTree abstraction

### DIFF
--- a/src/NexusMods.Paths/AbsolutePath.cs
+++ b/src/NexusMods.Paths/AbsolutePath.cs
@@ -93,18 +93,15 @@ public readonly partial struct AbsolutePath : IEquatable<AbsolutePath>, IPath<Ab
     /// <inheritdoc/>
     public IEnumerable<AbsolutePath> GetAllParents()
     {
-        var parentPath = this;
+        var currentPath = this;
         var root = GetRootDirectory();
 
-        // Always return the current path
-        yield return parentPath;
-        parentPath = parentPath.Parent;
-
-        while (parentPath != root)
+        while (currentPath != root)
         {
-            yield return parentPath;
-            parentPath = parentPath.Parent;
+            yield return currentPath;
+            currentPath = currentPath.Parent;
         }
+        yield return root;
     }
 
     /// <summary>

--- a/src/NexusMods.Paths/AbsolutePath.cs
+++ b/src/NexusMods.Paths/AbsolutePath.cs
@@ -55,8 +55,10 @@ public readonly partial struct AbsolutePath : IEquatable<AbsolutePath>, IPath<Ab
 
     /// <summary>
     /// Returns the FileName as a <see cref="RelativePath"/>.
-    /// If this is a root directory, returns <see cref="RelativePath.Empty"/>.
     /// </summary>
+    /// <remarks>
+    /// If this is a root directory, returns <see cref="RelativePath.Empty"/>.
+    /// </remarks>
     public RelativePath Name =>  string.IsNullOrEmpty(FileName) ? RelativePath.Empty : new RelativePath(FileName);
 
     /// <inheritdoc />

--- a/src/NexusMods.Paths/AbsolutePath.cs
+++ b/src/NexusMods.Paths/AbsolutePath.cs
@@ -285,6 +285,31 @@ public readonly partial struct AbsolutePath : IEquatable<AbsolutePath>, IPath<Ab
         return PathHelpers.InFolder(Directory, parentSpan, FileSystem.OS);
     }
 
+    /// <inheritdoc />
+    public bool StartsWith(AbsolutePath other)
+    {
+        var fullPath = GetFullPath();
+        var prefix = other.GetFullPath();
+
+        if (fullPath.Length < prefix.Length) return false;
+        if (fullPath.Length == prefix.Length) return Equals(other);
+        if (!fullPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        // If the other path is a parent of this path, then the next character must be a directory separator.
+        return fullPath[prefix.Length] == PathHelpers.DirectorySeparatorChar ||
+               // unless the prefix is a root directory
+               PathHelpers.IsRootDirectory(prefix, FileSystem.OS);
+    }
+
+    /// <inheritdoc />
+    public bool EndsWith(RelativePath other)
+    {
+        return GetNonRootPart().EndsWith(other);
+    }
+
     /// <summary/>
     public static bool operator ==(AbsolutePath lhs, AbsolutePath rhs) => lhs.Equals(rhs);
 

--- a/src/NexusMods.Paths/AbsolutePath.cs
+++ b/src/NexusMods.Paths/AbsolutePath.cs
@@ -272,11 +272,7 @@ public readonly partial struct AbsolutePath : IEquatable<AbsolutePath>, IPath<Ab
         return default;
     }
 
-    /// <summary>
-    /// Returns true if this path is a child of the specified path.
-    /// </summary>
-    /// <param name="parent">The path to verify.</param>
-    /// <returns>True if this is a child path of the parent path; else false.</returns>
+    /// <inheritdoc />
     public bool InFolder(AbsolutePath parent)
     {
         var parentLength = parent.GetFullPathLength();

--- a/src/NexusMods.Paths/FileTree/FileTreeNode.cs
+++ b/src/NexusMods.Paths/FileTree/FileTreeNode.cs
@@ -30,7 +30,7 @@ public class FileTreeNode<TPath, TValue> : IFileTree<FileTreeNode<TPath, TValue>
     {
         Path = path;
         Name = name;
-        _isFile = value != default;
+        _isFile = value != null;
         Value = value;
         _children = new Dictionary<RelativePath, FileTreeNode<TPath, TValue>>();
     }

--- a/src/NexusMods.Paths/FileTree/FileTreeNode.cs
+++ b/src/NexusMods.Paths/FileTree/FileTreeNode.cs
@@ -192,6 +192,9 @@ public class FileTreeNode<TPath, TValue> : IFileTree<FileTreeNode<TPath, TValue>
             // traverse the path from root to leaf and add missing nodes
             for (var i = 0; i < parentPaths.Length; i++)
             {
+                // if the path is rooted, skip the first path as it is the root component, which we already have
+                if (Path.IsRooted && i == 0) continue;
+
                 var subPath = parentPaths[i];
                 var subPathName = subPath.Name;
 

--- a/src/NexusMods.Paths/FileTree/FileTreeNode.cs
+++ b/src/NexusMods.Paths/FileTree/FileTreeNode.cs
@@ -100,11 +100,20 @@ public class FileTreeNode<TPath, TValue> : IFileTree<FileTreeNode<TPath, TValue>
     }
 
     /// <inheritdoc />
-    public IEnumerable<FileTreeNode<TPath, TValue>> GetAllFileDescendants()
+    public IEnumerable<FileTreeNode<TPath, TValue>> GetAllDescendentFiles()
     {
         if (IsFile) return Enumerable.Empty<FileTreeNode<TPath, TValue>>();
 
-        return Children.Values.SelectMany(x => x.GetAllFileDescendants());
+        return Children.Values.SelectMany(x => x.GetAllDescendentFiles());
+    }
+
+    /// <summary>
+    /// Returns a dictionary of all the file entries under the current node.
+    /// </summary>
+    /// <returns>A dictionary of with <see cref="Path"/> as keys and <see cref="Value"/> as values.</returns>
+    public Dictionary<TPath, TValue> GetAllDescendentFilesDictionary()
+    {
+        return GetAllDescendentFiles().ToDictionary(file => file.Path, file => file.Value!);
     }
 
     /// <summary>
@@ -131,6 +140,8 @@ public class FileTreeNode<TPath, TValue> : IFileTree<FileTreeNode<TPath, TValue>
         child._parent = this;
         _children.Add(child.Name, child);
     }
+
+
 
     /// <summary>
     /// Creates a tree structure from a collection of file entries.

--- a/src/NexusMods.Paths/FileTree/FileTreeNode.cs
+++ b/src/NexusMods.Paths/FileTree/FileTreeNode.cs
@@ -11,7 +11,7 @@ namespace NexusMods.Paths.FileTree;
 /// <typeparam name="TPath">The path type used in the tree</typeparam>
 /// <typeparam name="TValue"></typeparam>
 [PublicAPI]
-public class FileTreeNode<TPath, TValue> : IFileTree<FileTreeNode<TPath, TValue>, TPath>
+public class FileTreeNode<TPath, TValue> : IFileTree<FileTreeNode<TPath, TValue>>
     where TPath : struct, IPath<TPath>
 {
     private readonly bool _isFile;
@@ -153,11 +153,12 @@ public class FileTreeNode<TPath, TValue> : IFileTree<FileTreeNode<TPath, TValue>
     /// If the file paths are rooted, they all need to be sharing the same root component.
     /// If the paths are not rooted, they are assumed to be relative to the same unknown root.
     /// </remarks>
-    /// <param name="files">A collection of unique file entries in the form of TPath,TValue pairs.</param>
+    /// <param name="files">A non empty collection of unique file entries in the form of TPath,TValue pairs.</param>
     /// <returns>The root node of the generated tree.</returns>
-    public static FileTreeNode<TPath, TValue>? CreateTree(IEnumerable<KeyValuePair<TPath, TValue>> files)
+    /// <throws><see cref="ArgumentException"/> if the collection is empty.</throws>
+    public static FileTreeNode<TPath, TValue> CreateTree(IEnumerable<KeyValuePair<TPath, TValue>> files)
     {
-        if (!files.Any()) return null;
+        if (!files.Any()) throw new ArgumentException("Collection of files cannot be empty");
 
         var fileArray = files.ToArray();
         var rootComponent = fileArray.First().Key.GetRootComponent;

--- a/src/NexusMods.Paths/FileTree/FileTreeNode.cs
+++ b/src/NexusMods.Paths/FileTree/FileTreeNode.cs
@@ -21,8 +21,8 @@ public class FileTreeNode<TPath, TValue> : IFileTree<FileTreeNode<TPath, TValue>
 
     /// <summary>
     /// Constructs a new <see cref="FileTreeNode{TPath,TValue}"/> with the given path, name, parent and value.
-    /// NOTE: If the value is null, this node is assumed to be a directory, a file otherwise.
     /// </summary>
+    /// <remarks>If the value is null, this node is assumed to be a directory, a file otherwise.</remarks>
     /// <param name="path">The complete path for the node with respect to the root of the tree</param>
     /// <param name="name">The file name for the node</param>
     /// <param name="value">The associated value to be stored along a file entry. Should be null for directories.</param>
@@ -54,8 +54,7 @@ public class FileTreeNode<TPath, TValue> : IFileTree<FileTreeNode<TPath, TValue>
     public bool IsTreeRoot => !HasParent;
 
     /// <summary>
-    /// A value associated with a File entry.
-    /// Is null for directories.
+    /// A value associated with a File entry, null for directories.
     /// </summary>
     public TValue? Value { get; }
 
@@ -118,8 +117,10 @@ public class FileTreeNode<TPath, TValue> : IFileTree<FileTreeNode<TPath, TValue>
 
     /// <summary>
     /// Adds a collection of nodes as children to this node.
-    /// Sets the parent of the children to this node.
     /// </summary>
+    /// <remarks>
+    /// Sets the parent of the children to this node.
+    /// </remarks>
     /// <param name="children">The collection of nodes to be added</param>
     public void AddChildren(IEnumerable<FileTreeNode<TPath, TValue>> children)
     {
@@ -132,8 +133,10 @@ public class FileTreeNode<TPath, TValue> : IFileTree<FileTreeNode<TPath, TValue>
 
     /// <summary>
     /// Adds a node as a child to this node.
-    /// Sets the parent of the child to this node.
     /// </summary>
+    /// <remarks>
+    /// Sets the parent of the child to this node.
+    /// </remarks>
     /// <param name="child">The node to be added</param>
     public void AddChild(FileTreeNode<TPath, TValue> child)
     {
@@ -145,10 +148,11 @@ public class FileTreeNode<TPath, TValue> : IFileTree<FileTreeNode<TPath, TValue>
 
     /// <summary>
     /// Creates a tree structure from a collection of file entries.
-    ///
-    /// NOTE: If the file paths are rooted, they all need to be sharing the same root component.
-    /// If the paths are not rooted, they are assumed to be relative to the same unknown root.
     /// </summary>
+    /// <remarks>
+    /// If the file paths are rooted, they all need to be sharing the same root component.
+    /// If the paths are not rooted, they are assumed to be relative to the same unknown root.
+    /// </remarks>
     /// <param name="files">A collection of unique file entries in the form of TPath,TValue pairs.</param>
     /// <returns>The root node of the generated tree.</returns>
     public static FileTreeNode<TPath, TValue>? CreateTree(IEnumerable<KeyValuePair<TPath, TValue>> files)
@@ -169,9 +173,11 @@ public class FileTreeNode<TPath, TValue> : IFileTree<FileTreeNode<TPath, TValue>
 
     /// <summary>
     /// Populates the tree with the given collection of file entries.
+    /// </summary>
+    /// <remarks>
     /// The current node is assumed to be the root of the tree.
     /// All file paths are assumed to be relative to the root of the tree.
-    /// </summary>
+    /// </remarks>
     /// <param name="files">A collection of unique files in the form of TPath,TValue pairs.</param>
     /// <exception cref="InvalidOperationException">If there are duplicate file entries.</exception>
     protected void PopulateTree(IEnumerable<KeyValuePair<TPath, TValue>> files)

--- a/src/NexusMods.Paths/FileTree/FileTreeNode.cs
+++ b/src/NexusMods.Paths/FileTree/FileTreeNode.cs
@@ -1,0 +1,204 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+
+namespace NexusMods.Paths.FileTree;
+
+/// <summary>
+/// Represents a generic tree of files with some associated value.
+/// </summary>
+/// <typeparam name="TPath">The path type used in the tree</typeparam>
+/// <typeparam name="TValue"></typeparam>
+[PublicAPI]
+public class FileTreeNode<TPath, TValue> : IFileTree<FileTreeNode<TPath, TValue>, TPath>
+    where TPath : struct, IPath<TPath>, IEquatable<TPath>
+{
+    private readonly bool _isFile;
+
+    private readonly Dictionary<RelativePath, FileTreeNode<TPath, TValue>> _children;
+    private FileTreeNode<TPath, TValue>? _parent;
+
+    /// <summary>
+    /// Constructs a new <see cref="FileTreeNode{TPath,TValue}"/> with the given path, name, parent and value.
+    /// NOTE: If the value is null, this node is assumed to be a directory, a file otherwise.
+    /// </summary>
+    /// <param name="path">The complete path for the node with respect to the root of the tree</param>
+    /// <param name="name">The file name for the node</param>
+    /// <param name="value">The associated value to be stored along a file entry. Should be null for directories.</param>
+    public FileTreeNode(TPath path, RelativePath name, TValue? value)
+    {
+        Path = path;
+        Name = name;
+        _isFile = value != null;
+        Value = value;
+        _children = new Dictionary<RelativePath, FileTreeNode<TPath, TValue>>();
+    }
+
+    /// <inheritdoc />
+    public TPath Path { get; }
+
+    /// <inheritdoc />
+    public RelativePath Name { get; }
+
+    /// <inheritdoc />
+    public bool IsFile => _isFile;
+
+    /// <inheritdoc />
+    public bool IsDirectory => !_isFile;
+
+    /// <inheritdoc />
+    public bool HasParent => _parent != null;
+
+    /// <inheritdoc />
+    public bool IsTreeRoot => !HasParent;
+
+    /// <summary>
+    /// A value associated with a File entry.
+    /// Is null for directories.
+    /// </summary>
+    public TValue? Value { get; }
+
+    /// <inheritdoc />
+    public IDictionary<RelativePath, FileTreeNode<TPath, TValue>> Children => _children;
+
+    /// <inheritdoc />
+    public FileTreeNode<TPath, TValue> Parent
+    {
+        get
+        {
+            if (_parent == null)
+            {
+                throw new InvalidOperationException("Root node has no parent");
+            }
+
+            return _parent;
+        }
+    }
+
+    /// <inheritdoc />
+    public FileTreeNode<TPath, TValue> Root
+    {
+        get
+        {
+            var current = this;
+            while (current.HasParent)
+            {
+                current = current.Parent;
+            }
+
+            return current;
+        }
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<FileTreeNode<TPath, TValue>> GetSiblings()
+    {
+        if (IsTreeRoot) return Enumerable.Empty<FileTreeNode<TPath, TValue>>();
+
+        return Parent.Children.Values.Where(x => x != this);
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<FileTreeNode<TPath, TValue>> GetAllFileDescendants()
+    {
+        if (IsFile) return Enumerable.Empty<FileTreeNode<TPath, TValue>>();
+
+        return Children.Values.SelectMany(x => x.GetAllFileDescendants());
+    }
+
+    /// <summary>
+    /// Adds a collection of nodes as children to this node.
+    /// Sets the parent of the children to this node.
+    /// </summary>
+    /// <param name="children">The collection of nodes to be added</param>
+    public void AddChildren(IEnumerable<FileTreeNode<TPath, TValue>> children)
+    {
+        foreach (var child in children)
+        {
+            child._parent = this;
+            AddChild(child);
+        }
+    }
+
+    /// <summary>
+    /// Adds a node as a child to this node.
+    /// Sets the parent of the child to this node.
+    /// </summary>
+    /// <param name="child">The node to be added</param>
+    public void AddChild(FileTreeNode<TPath, TValue> child)
+    {
+        child._parent = this;
+        _children.Add(child.Name, child);
+    }
+
+    /// <summary>
+    /// Creates a tree structure from a collection of file entries.
+    ///
+    /// NOTE: If the file paths are rooted, they all need to be sharing the same root component.
+    /// If the paths are not rooted, they are assumed to be relative to the same unknown root.
+    /// </summary>
+    /// <param name="files">A collection of unique file entries in the form of TPath,TValue pairs.</param>
+    /// <returns>The root node of the generated tree.</returns>
+    public static FileTreeNode<TPath, TValue>? CreateTree(IEnumerable<KeyValuePair<TPath, TValue>> files)
+    {
+        if (!files.Any()) return null;
+
+        var fileArray = files.ToArray();
+        var rootComponent = fileArray.First().Key.GetRootComponent;
+
+        // If paths are rooted, we assume all the passed paths share the same root
+        // If paths are not rooted, we assume they are all relative to the same unknown root (RelativePath.Empty)
+        var rootNode = new FileTreeNode<TPath, TValue>(rootComponent, RelativePath.Empty, default);
+
+        rootNode.PopulateTree(fileArray);
+
+        return rootNode;
+    }
+
+    /// <summary>
+    /// Populates the tree with the given collection of file entries.
+    /// The current node is assumed to be the root of the tree.
+    /// All file paths are assumed to be relative to the root of the tree.
+    /// </summary>
+    /// <param name="files">A collection of unique files in the form of TPath,TValue pairs.</param>
+    /// <exception cref="InvalidOperationException">If there are duplicate file entries.</exception>
+    protected void PopulateTree(IEnumerable<KeyValuePair<TPath, TValue>> files)
+    {
+        foreach (var fileEntry in files)
+        {
+            var parentNode = this;
+            var currentFullPath = fileEntry.Key;
+
+            var parentPaths = currentFullPath.GetAllParents().Reverse().ToArray();
+
+            // traverse the path from root to leaf and add missing nodes
+            for (var i = 0; i < parentPaths.Length; i++)
+            {
+                var subPath = parentPaths[i];
+                var subPathName = subPath.Name;
+
+                if (parentNode.Children.TryGetValue(subPathName, out var existing))
+                {
+                    // if we are at the last path, this is the file
+                    if (i == parentPaths.Length - 1)
+                    {
+                        throw new InvalidOperationException($"Duplicate path found for file: {subPath}");
+                    }
+
+                    parentNode = existing;
+                    continue;
+                }
+
+                // if we are at the last path, this is the file
+                var value = i == parentPaths.Length - 1 ? fileEntry.Value : default;
+
+                var node = new FileTreeNode<TPath, TValue>(subPath, subPathName, value);
+
+                parentNode.AddChild(node);
+
+                parentNode = node;
+            }
+        }
+    }
+}

--- a/src/NexusMods.Paths/FileTree/FileTreeNode.cs
+++ b/src/NexusMods.Paths/FileTree/FileTreeNode.cs
@@ -12,7 +12,7 @@ namespace NexusMods.Paths.FileTree;
 /// <typeparam name="TValue"></typeparam>
 [PublicAPI]
 public class FileTreeNode<TPath, TValue> : IFileTree<FileTreeNode<TPath, TValue>, TPath>
-    where TPath : struct, IPath<TPath>, IEquatable<TPath>
+    where TPath : struct, IPath<TPath>
 {
     private readonly bool _isFile;
 

--- a/src/NexusMods.Paths/FileTree/IFileTree.cs
+++ b/src/NexusMods.Paths/FileTree/IFileTree.cs
@@ -45,8 +45,10 @@ public interface IFileTree<TFileTree, TPath> where TFileTree : IFileTree<TFileTr
 
     /// <summary>
     /// A Dictionary containing all the children of this node, both files and directories.
-    /// The key is the <see cref="Name"/> of the child.
     /// </summary>
+    /// <remarks>
+    /// The key is the <see cref="Name"/> of the child.
+    /// </remarks>
     public IDictionary<RelativePath, TFileTree> Children { get; }
 
     /// <summary>
@@ -61,13 +63,17 @@ public interface IFileTree<TFileTree, TPath> where TFileTree : IFileTree<TFileTr
 
     /// <summary>
     /// A collection of all sibling nodes, excluding this one.
-    /// Returns an empty collection if this node is the root.
     /// </summary>
+    /// <remarks>
+    /// Returns an empty collection if this node is the root.
+    /// </remarks>
     public IEnumerable<TFileTree> GetSiblings();
 
     /// <summary>
     /// A collection of all File nodes that descend from this one.
-    /// Returns an empty collection if this node is a file.
     /// </summary>
+    /// <remarks>
+    /// Returns an empty collection if this node is a file.
+    /// </remarks>
     public IEnumerable<TFileTree> GetAllDescendentFiles();
 }

--- a/src/NexusMods.Paths/FileTree/IFileTree.cs
+++ b/src/NexusMods.Paths/FileTree/IFileTree.cs
@@ -8,15 +8,9 @@ namespace NexusMods.Paths.FileTree;
 /// Represents a generic tree of files.
 /// </summary>
 /// <typeparam name="TFileTree">Allows implementations to return concrete types</typeparam>
-/// <typeparam name="TPath">The path type being used in the tree</typeparam>
 [PublicAPI]
-public interface IFileTree<TFileTree, TPath> where TFileTree : IFileTree<TFileTree, TPath>
-    where TPath : struct, IPath<TPath>
+public interface IFileTree<TFileTree> where TFileTree : IFileTree<TFileTree>
 {
-    /// <summary>
-    /// The complete path of the node with respect to the root of the tree.
-    /// </summary>
-    public TPath Path { get; }
 
     /// <summary>
     /// The file name for this node.

--- a/src/NexusMods.Paths/FileTree/IFileTree.cs
+++ b/src/NexusMods.Paths/FileTree/IFileTree.cs
@@ -11,7 +11,7 @@ namespace NexusMods.Paths.FileTree;
 /// <typeparam name="TPath">The path type being used in the tree</typeparam>
 [PublicAPI]
 public interface IFileTree<TFileTree, TPath> where TFileTree : IFileTree<TFileTree, TPath>
-    where TPath : struct, IPath<TPath>, IEquatable<TPath>
+    where TPath : struct, IPath<TPath>
 {
     /// <summary>
     /// The complete path of the node with respect to the root of the tree.

--- a/src/NexusMods.Paths/FileTree/IFileTree.cs
+++ b/src/NexusMods.Paths/FileTree/IFileTree.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+
+namespace NexusMods.Paths.FileTree;
+
+/// <summary>
+/// Represents a generic tree of files.
+/// </summary>
+/// <typeparam name="TFileTree">Allows implementations to return concrete types</typeparam>
+/// <typeparam name="TPath">The path type being used in the tree</typeparam>
+[PublicAPI]
+public interface IFileTree<TFileTree, TPath> where TFileTree : IFileTree<TFileTree, TPath>
+    where TPath : struct, IPath<TPath>, IEquatable<TPath>
+{
+    /// <summary>
+    /// The complete path of the node with respect to the root of the tree.
+    /// </summary>
+    public TPath Path { get; }
+
+    /// <summary>
+    /// The file name for this node.
+    /// </summary>
+    public RelativePath Name { get; }
+
+    /// <summary>
+    /// Returns true if node is assumed to be a file.
+    /// </summary>
+    public bool IsFile { get; }
+
+    /// <summary>
+    /// Returns true if node is assumed to be a directory.
+    /// </summary>
+    public bool IsDirectory { get; }
+
+    /// <summary>
+    /// Returns true if node is the root of the tree.
+    /// </summary>
+    public bool IsTreeRoot { get; }
+
+    /// <summary>
+    /// Returns tre if node has a parent.
+    /// </summary>
+    public bool HasParent { get; }
+
+    /// <summary>
+    /// A Dictionary containing all the children of this node, both files and directories.
+    /// The key is the <see cref="Name"/> of the child.
+    /// </summary>
+    public IDictionary<RelativePath, TFileTree> Children { get; }
+
+    /// <summary>
+    /// Returns the parent node if it exists, throws InvalidOperationException otherwise.
+    /// </summary>
+    public TFileTree Parent { get; }
+
+    /// <summary>
+    /// Returns the root node of the tree.
+    /// </summary>
+    public TFileTree Root { get; }
+
+    /// <summary>
+    /// A collection of all sibling nodes, excluding this one.
+    /// Returns an empty collection if this node is the root.
+    /// </summary>
+    public IEnumerable<TFileTree> GetSiblings();
+
+    /// <summary>
+    /// A collection of all File nodes that descend from this one.
+    /// Returns an empty collection if this node is a file.
+    /// </summary>
+    public IEnumerable<TFileTree> GetAllFileDescendants();
+}

--- a/src/NexusMods.Paths/FileTree/IFileTree.cs
+++ b/src/NexusMods.Paths/FileTree/IFileTree.cs
@@ -69,5 +69,5 @@ public interface IFileTree<TFileTree, TPath> where TFileTree : IFileTree<TFileTr
     /// A collection of all File nodes that descend from this one.
     /// Returns an empty collection if this node is a file.
     /// </summary>
-    public IEnumerable<TFileTree> GetAllFileDescendants();
+    public IEnumerable<TFileTree> GetAllDescendentFiles();
 }

--- a/src/NexusMods.Paths/IPath.cs
+++ b/src/NexusMods.Paths/IPath.cs
@@ -26,7 +26,7 @@ public interface IPath
 /// </summary>
 /// <typeparam name="TConcretePath">Concrete path type returned by method implementations</typeparam>
 [PublicAPI]
-public interface IPath<TConcretePath> : IPath where TConcretePath : struct, IPath<TConcretePath>
+public interface IPath<TConcretePath> : IPath where TConcretePath : struct, IPath<TConcretePath>, IEquatable<TConcretePath>
 {
     /// <summary>
     /// The file name of this path.
@@ -75,4 +75,11 @@ public interface IPath<TConcretePath> : IPath where TConcretePath : struct, IPat
     /// Returns whether this path is rooted.
     /// </summary>
     bool IsRooted { get; }
+
+    /// <summary>
+    /// Returns true if this path is a child of the specified path.
+    /// </summary>
+    /// <param name="parent">The potential parent path</param>
+    /// <returns>True if this is a child path of the parent path; else false.</returns>
+    bool InFolder(TConcretePath parent);
 }

--- a/src/NexusMods.Paths/IPath.cs
+++ b/src/NexusMods.Paths/IPath.cs
@@ -26,7 +26,7 @@ public interface IPath
 /// </summary>
 /// <typeparam name="TConcretePath">Concrete path type returned by method implementations</typeparam>
 [PublicAPI]
-public interface IPath<TConcretePath> : IPath where TConcretePath : struct, IPath<TConcretePath>, IEquatable<TConcretePath>
+public interface IPath<TConcretePath> : IPath where TConcretePath : struct, IPath<TConcretePath>
 {
     /// <summary>
     /// The file name of this path.

--- a/src/NexusMods.Paths/IPath.cs
+++ b/src/NexusMods.Paths/IPath.cs
@@ -60,15 +60,18 @@ public interface IPath<TConcretePath> : IPath where TConcretePath : struct, IPat
 
     /// <summary>
     /// Returns a collection of parts that make up this path, excluding root components.
-    /// NOTE: Root components like `C:/` are excluded and should be handled separately.
     /// </summary>
+    /// <remarks>
+    /// Root components like `C:/` are excluded and should be handled separately.
+    /// </remarks>
     IEnumerable<RelativePath> Parts { get; }
 
     /// <summary>
     /// Returns a collection of all parent paths, including this path.
-    /// Order is from this path to the root.
     /// </summary>
-    /// <returns></returns>
+    /// <remarks>
+    /// Order is from this path to the root.
+    /// </remarks>
     IEnumerable<TConcretePath> GetAllParents();
 
     /// <summary>

--- a/src/NexusMods.Paths/IPath.cs
+++ b/src/NexusMods.Paths/IPath.cs
@@ -80,6 +80,20 @@ public interface IPath<TConcretePath> : IPath where TConcretePath : struct, IPat
     /// Returns true if this path is a child of the specified path.
     /// </summary>
     /// <param name="parent">The potential parent path</param>
+    /// <remarks>The child path needs to have greater depth than the parent.</remarks>
     /// <returns>True if this is a child path of the parent path; else false.</returns>
     bool InFolder(TConcretePath parent);
+
+    /// <summary>
+    /// Returns true if this path starts with the specified path.
+    /// </summary>
+    /// <param name="other">The prefix path</param>
+    bool StartsWith(TConcretePath other);
+
+    /// <summary>
+    /// Returns true if this path ends with the specified RelativePath.
+    /// </summary>
+    /// <remarks>Since RelativePaths can't contain Root components, this check won't consider root folders</remarks>
+    /// <param name="other">The relative path with which this path is supposed to end</param>
+    bool EndsWith(RelativePath other);
 }

--- a/src/NexusMods.Paths/IPath.cs
+++ b/src/NexusMods.Paths/IPath.cs
@@ -37,14 +37,6 @@ public interface IPath<TConcretePath> : IPath where TConcretePath : struct, IPat
     RelativePath Name { get; }
 
     /// <summary>
-    /// Gets the extension of this path.
-    /// </summary>
-    /// <remarks>
-    /// Returns an empty <see cref="Extension"/> if no extension is present.
-    /// </remarks>
-    Extension Extension { get; }
-
-    /// <summary>
     /// Traverses one directory up, returning the path of the parent.
     /// </summary>
     /// <remarks>

--- a/src/NexusMods.Paths/IPath.cs
+++ b/src/NexusMods.Paths/IPath.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+
 namespace NexusMods.Paths;
 
 /// <summary>
@@ -14,4 +18,66 @@ public interface IPath
     /// Gets the file name of this path.
     /// </summary>
     RelativePath FileName { get; }
+}
+
+/// <summary>
+/// Abstracts an individual path.
+/// Allows methods to return specific path types.
+/// </summary>
+/// <typeparam name="TConcretePath">Concrete path type returned by method implementations</typeparam>
+[PublicAPI]
+public interface IPath<TConcretePath> : IPath where TConcretePath : struct, IPath<TConcretePath>, IEquatable<TConcretePath>
+{
+    /// <summary>
+    /// The file name of this path.
+    /// </summary>
+    /// <remarks>
+    /// Returns an empty <see cref="RelativePath"/> if this path is a root component.
+    /// </remarks>
+    RelativePath Name { get; }
+
+    /// <summary>
+    /// Gets the extension of this path.
+    /// </summary>
+    /// <remarks>
+    /// Returns an empty <see cref="Extension"/> if no extension is present.
+    /// </remarks>
+    Extension Extension { get; }
+
+    /// <summary>
+    /// Traverses one directory up, returning the path of the parent.
+    /// </summary>
+    /// <remarks>
+    /// If the path is a root component, returns the root component.
+    /// If path is not rooted and there are no parent directories, returns an empty path.
+    /// </remarks>
+    TConcretePath Parent { get; }
+
+    /// <summary>
+    /// If this path is rooted, returns the root component, an empty path otherwise.
+    /// </summary>
+    TConcretePath GetRootComponent { get; }
+
+    /// <summary>
+    /// Returns a collection of parts that make up this path, excluding root components.
+    /// NOTE: Root components like `C:/` are excluded and should be handled separately.
+    /// </summary>
+    IEnumerable<RelativePath> Parts { get; }
+
+    /// <summary>
+    /// Returns a collection of all parent paths, including this path.
+    /// Order is from this path to the root.
+    /// </summary>
+    /// <returns></returns>
+    IEnumerable<TConcretePath> GetAllParents();
+
+    /// <summary>
+    /// Returns a <see cref="RelativePath"/> of the non-root part of this path.
+    /// </summary>
+    RelativePath GetNonRootPart();
+
+    /// <summary>
+    /// Returns whether this path is rooted.
+    /// </summary>
+    bool IsRooted { get; }
 }

--- a/src/NexusMods.Paths/RelativePath.cs
+++ b/src/NexusMods.Paths/RelativePath.cs
@@ -212,11 +212,16 @@ public readonly struct RelativePath : IPath<RelativePath>, IEquatable<RelativePa
     /// <summary>
     /// Returns a path relative to the sub-path specified.
     /// </summary>
+    /// <remarks>
+    /// Returns an empty path if <paramref name="basePath"/> matches this path.
+    /// </remarks>
     /// <param name="basePath">The sub-path specified.</param>
+    /// <throws><see cref="PathException"/> if <paramref name="basePath"/> is not a parent of this path.</throws>
     public RelativePath RelativeTo(RelativePath basePath)
     {
         var other = basePath.Path;
         if (other.Length == 0) return this;
+        if (basePath.Path == Path) return Empty;
 
         var res = PathHelpers.RelativeTo(Path, other, OS);
         if (!res.IsEmpty) return new RelativePath(res.ToString());

--- a/src/NexusMods.Paths/RelativePath.cs
+++ b/src/NexusMods.Paths/RelativePath.cs
@@ -38,7 +38,7 @@ public readonly struct RelativePath : IPath<RelativePath>, IEquatable<RelativePa
     public Extension Extension => Extension.FromPath(Path);
 
     /// <summary>
-    /// R
+    /// Returns the file name of this path.
     /// </summary>
     public RelativePath FileName => Name;
 
@@ -105,7 +105,7 @@ public readonly struct RelativePath : IPath<RelativePath>, IEquatable<RelativePa
     /// Obtains the name of the first folder stored in this path.
     /// </summary>
     /// <remarks>
-    ///    This will return empty string if there are no child directories.
+    /// This will return empty string if there are no child directories.
     /// </remarks>
     public RelativePath TopParent
     {
@@ -130,7 +130,6 @@ public readonly struct RelativePath : IPath<RelativePath>, IEquatable<RelativePa
     /// Creates a new <see cref="RelativePath"/> from a <see cref="ReadOnlySpan{T}"/>.
     /// </summary>
     /// <param name="path"></param>
-    /// <returns></returns>
     public static RelativePath FromUnsanitizedInput(ReadOnlySpan<char> path)
     {
         return new RelativePath(PathHelpers.Sanitize(path, OS));

--- a/src/NexusMods.Paths/RelativePath.cs
+++ b/src/NexusMods.Paths/RelativePath.cs
@@ -181,12 +181,42 @@ public readonly struct RelativePath : IPath<RelativePath>, IEquatable<RelativePa
         return Path.AsSpan().StartsWith(other, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <inheritdoc/>
+    public bool StartsWith(RelativePath other)
+    {
+        if (other.Path.Length == 0) return true;
+        if (other.Path.Length > Path.Length) return false;
+        if (other.Path.Length == Path.Length) return Equals(other);
+        if (!Path.AsSpan().StartsWith(other.Path, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        // If the other path is a parent of this path, then the next character must be a directory separator.
+        return Path[other.Path.Length] == PathHelpers.DirectorySeparatorChar;
+    }
+
     /// <summary>
     /// Returns true if the relative path ends with a given string.
     /// </summary>
     public bool EndsWith(ReadOnlySpan<char> other)
     {
         return Path.AsSpan().EndsWith(other, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <inheritdoc/>
+    public bool EndsWith(RelativePath other)
+    {
+        if (other.Path.Length == 0) return true;
+        if (other.Path.Length > Path.Length) return false;
+        if (other.Path.Length == Path.Length) return Equals(other);
+        if (!Path.AsSpan().EndsWith(other.Path, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        // If this path ends with other but is longer, then the character before the other path must be a directory separator.
+        return Path[Path.Length - other.Path.Length - 1] == PathHelpers.DirectorySeparatorChar;
     }
 
     /// <inheritdoc />

--- a/src/NexusMods.Paths/RelativePath.cs
+++ b/src/NexusMods.Paths/RelativePath.cs
@@ -72,8 +72,12 @@ public readonly struct RelativePath : IPath<RelativePath>, IEquatable<RelativePa
     {
         get
         {
-            return PathHelpers.GetParts(Path, OS)
-                .Select(x => new RelativePath(x.ToString()));
+            var currentPath = this;
+            while (currentPath.Path != Empty)
+            {
+                yield return currentPath.Name;
+                currentPath = currentPath.Parent;
+            }
         }
     }
 

--- a/src/NexusMods.Paths/RelativePath.cs
+++ b/src/NexusMods.Paths/RelativePath.cs
@@ -189,11 +189,7 @@ public readonly struct RelativePath : IPath<RelativePath>, IEquatable<RelativePa
         return Path.AsSpan().EndsWith(other, StringComparison.OrdinalIgnoreCase);
     }
 
-    /// <summary>
-    /// Returns true if this path is a child of this path.
-    /// </summary>
-    /// <param name="other">The path to verify.</param>
-    /// <returns>True if this is a child path of the parent path; else false.</returns>
+    /// <inheritdoc />
     public bool InFolder(RelativePath other)
     {
         return PathHelpers.InFolder(Path, other.Path, OS);

--- a/tests/NexusMods.Paths.Tests/AbsolutePathTests.cs
+++ b/tests/NexusMods.Paths.Tests/AbsolutePathTests.cs
@@ -139,7 +139,8 @@ public class AbsolutePathTests
     [InlineData(false, "C:/", "C:/", "", "C:/")]
     [InlineData(false, "C:/foo", "C:/", "", "C:/")]
     [InlineData(false, "C:/foo/bar", "C:/", "foo", "C:/foo")]
-    public void Test_Parent(bool isUnix, string input, string expectedDirectory, string expectedFileName, string expectedFullPath)
+    public void Test_Parent(bool isUnix, string input, string expectedDirectory, string expectedFileName,
+        string expectedFullPath)
     {
         var path = CreatePath(input, isUnix);
         var actualParent = path.Parent;
@@ -217,17 +218,13 @@ public class AbsolutePathTests
     }
 
     [Theory]
-    [InlineData(true, "", "", true)]
-    [InlineData(true, "foo", "", true)]
-    [InlineData(true, "", "foo", false)]
-    [InlineData(true, "foo/bar", "foo", true)]
-    [InlineData(true, "foo", "bar", false)]
     [InlineData(true, "/", "/", true)]
     [InlineData(true, "/foo", "/", true)]
     [InlineData(true, "/foo/bar/baz", "/", true)]
     [InlineData(true, "/foo/bar/baz", "/foo", true)]
     [InlineData(true, "/foo/bar/baz", "/foo/bar", true)]
     [InlineData(true, "/foobar", "/foo", false)]
+    [InlineData(true, "/foo/bar/baz", "/foo/baz", false)]
     [InlineData(false, "C:/", "C:/", true)]
     [InlineData(false, "C:/foo", "C:/", true)]
     [InlineData(false, "C:/foo/bar/baz", "C:/", true)]
@@ -239,6 +236,57 @@ public class AbsolutePathTests
         var childPath = CreatePath(child, isUnix);
         var parentPath = CreatePath(parent, isUnix);
         var actual = childPath.InFolder(parentPath);
+        actual.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(true, "/", "/", true)]
+    [InlineData(true, "/", "/foo", false)]
+    [InlineData(true, "/foo", "/bar", false)]
+    [InlineData(true, "/foo", "/", true)]
+    [InlineData(true, "/foo/bar/baz", "/", true)]
+    [InlineData(true, "/foo/bar/baz", "/foo", true)]
+    [InlineData(true, "/foo/bar/baz", "/foo/bar", true)]
+    [InlineData(true, "/foobar", "/foo", false)]
+    [InlineData(true, "/foo/bar/baz", "/foo/baz", false)]
+    [InlineData(false, "C:/", "C:/", true)]
+    [InlineData(false, "C:/foo", "C:/", true)]
+    [InlineData(false, "C:/foo/bar/baz", "C:/", true)]
+    [InlineData(false, "C:/foo/bar/baz", "C:/foo", true)]
+    [InlineData(false, "C:/foo/bar/baz", "C:/foo/bar", true)]
+    [InlineData(false, "C:/foobar", "C:/foo", false)]
+    public void Test_StartsWith(bool isUnix, string child, string parent, bool expected)
+    {
+        var childPath = CreatePath(child, isUnix);
+        var parentPath = CreatePath(parent, isUnix);
+        var actual = childPath.StartsWith(parentPath);
+        actual.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(true, "/", "", true)]
+    [InlineData(true, "/", "foo", false)]
+    [InlineData(true, "/foo", "bar", false)]
+    [InlineData(true, "/foo", "", true)]
+    [InlineData(true, "/foo/bar/baz", "", true)]
+    [InlineData(true, "/foo/bar/baz", "bar/baz", true)]
+    [InlineData(true, "/foo/bar/baz", "foo/bar/baz", true)]
+    [InlineData(true, "/foobar", "bar", false)]
+    [InlineData(true, "/foo/bar/baz", "foo/baz", false)]
+    [InlineData(false, "C:/", "", true)]
+    [InlineData(false, "C:/", "foo", false)]
+    [InlineData(false, "C:/foo", "bar", false)]
+    [InlineData(false, "C:/foo", "", true)]
+    [InlineData(false, "C:/foo/bar/baz", "", true)]
+    [InlineData(false, "C:/foo/bar/baz", "bar/baz", true)]
+    [InlineData(false, "C:/foo/bar/baz", "foo/bar/baz", true)]
+    [InlineData(false, "C:/foobar", "bar", false)]
+    [InlineData(false, "C:/foo/bar/baz", "foo/baz", false)]
+    public void Test_EndsWith(bool isUnix, string path, string end, bool expected)
+    {
+        var startingPath = CreatePath(path, isUnix);
+        var endPath = (RelativePath)end;
+        var actual = startingPath.EndsWith(endPath);
         actual.Should().Be(expected);
     }
 

--- a/tests/NexusMods.Paths.Tests/FileTree/AbsoluteFileTreeTests.cs
+++ b/tests/NexusMods.Paths.Tests/FileTree/AbsoluteFileTreeTests.cs
@@ -1,0 +1,250 @@
+﻿using System.Runtime.InteropServices;
+using NexusMods.Paths.FileTree;
+
+namespace NexusMods.Paths.Tests.FileTree;
+
+public class AbsoluteFileTreeTests
+{
+    [Theory]
+    [InlineData("/file1.txt", true, true, 1)]
+    [InlineData("/file2.txt", true, false, 2)]
+    [InlineData("/foo/file2.txt", true, true, 2)]
+    [InlineData("/foo/file3.txt", true, true, 3)]
+    [InlineData("/foo/bar/file4.txt", true, true, 4)]
+    [InlineData("/baz/bazer/file5.txt", true, true, 5)]
+    [InlineData("/bazer/file5.txt", true, false, 5)]
+    [InlineData("C:/file1.txt", false, true, 1)]
+    [InlineData("C:/file2.txt", false, false, 2)]
+    [InlineData("C:/foo/file2.txt", false, true, 2)]
+    [InlineData("C:/foo/file3.txt", false, true, 3)]
+    [InlineData("C:/foo/bar/file4.txt", false, true, 4)]
+    [InlineData("C:/baz/bazer/file5.txt", false, true, 5)]
+    [InlineData("C:/bazer/file5.txt", false, false, 5)]
+    public void Test_FindNode(string path, bool isUnix, bool found, int value)
+    {
+        var tree = MakeTestTree(isUnix);
+
+        var node = tree.FindNode(CreateAbsPath(path, isUnix));
+        if (found)
+        {
+            node.Should().NotBeNull();
+            node!.Path.Should().Be(CreateAbsPath(path, isUnix));
+            node!.Value.Should().Be(value);
+        }
+        else
+        {
+            node.Should().BeNull();
+        }
+    }
+
+    [Theory]
+    [InlineData("/file1.txt", true, "file1.txt")]
+    [InlineData("/foo", true, "foo")]
+    [InlineData("/foo/file2.txt", true, "file2.txt")]
+    [InlineData("/foo/file3.txt", true, "file3.txt")]
+    [InlineData("/foo/bar", true, "bar")]
+    [InlineData("/foo/bar/file4.txt", true, "file4.txt")]
+    [InlineData("/baz/bazer", true, "bazer")]
+    [InlineData("/baz/bazer/file5.txt", true, "file5.txt")]
+    [InlineData("C:/file1.txt", false, "file1.txt")]
+    [InlineData("C:/foo", false, "foo")]
+    [InlineData("C:/foo/file2.txt", false, "file2.txt")]
+    [InlineData("C:/foo/file3.txt", false, "file3.txt")]
+    [InlineData("C:/foo/bar", false, "bar")]
+    public void Test_Name(string path, bool isUnix, string name)
+    {
+        var tree = MakeTestTree(isUnix);
+
+        var node = tree.FindNode(CreateAbsPath(path, isUnix));
+        node.Should().NotBeNull();
+        node!.Name.Should().Be((RelativePath)name);
+    }
+
+    [Theory]
+    [InlineData("/file1.txt", true, true)]
+    [InlineData("/foo", true, false)]
+    [InlineData("/foo/file2.txt", true, true)]
+    [InlineData("/foo/file3.txt", true, true)]
+    [InlineData("/foo/bar", true, false)]
+    [InlineData("/foo/bar/file4.txt", true, true)]
+    [InlineData("/baz/bazer", true, false)]
+    [InlineData("/baz/bazer/file5.txt", true, true)]
+    [InlineData("C:/file1.txt", false, true)]
+    [InlineData("C:/foo", false, false)]
+    [InlineData("C:/foo/file2.txt", false, true)]
+    [InlineData("C:/foo/file3.txt", false, true)]
+    [InlineData("C:/foo/bar", false, false)]
+    public void Test_IsFile(string path, bool isUnix, bool isFile)
+    {
+        var tree = MakeTestTree(isUnix);
+
+        var node = tree.FindNode(CreateAbsPath(path, isUnix));
+        node.Should().NotBeNull();
+        node!.IsFile.Should().Be(isFile);
+    }
+
+
+
+    [Theory]
+    [InlineData("/", true, false)]
+    [InlineData("/file1.txt", true, true)]
+    [InlineData("/foo", true, true)]
+    [InlineData("/foo/file2.txt", true, true)]
+    [InlineData("C:/", false, false)]
+    [InlineData("C:/file1.txt", false, true)]
+    [InlineData("C:/foo", false, true)]
+    [InlineData("C:/foo/file2.txt", false, true)]
+    public void Test_HasParent(string path, bool isUnix, bool hasParent)
+    {
+        var tree = MakeTestTree(isUnix);
+
+        var node = tree.FindNode(CreateAbsPath(path, isUnix));
+        node.Should().NotBeNull();
+        node!.HasParent.Should().Be(hasParent);
+        if (hasParent)
+        {
+            node!.Parent.Should().NotBeNull();
+        }
+    }
+
+    [Theory]
+    [InlineData("/", true, true)]
+    [InlineData("/file1.txt", true, false)]
+    [InlineData("/foo", true, false)]
+    [InlineData("/foo/file2.txt", true, false)]
+    [InlineData("C:/", false, true)]
+    [InlineData("C:/file1.txt", false, false)]
+    [InlineData("C:/foo", false, false)]
+    [InlineData("C:/foo/file2.txt", false, false)]
+    public void Test_IsTreeRoot(string path, bool isUnix, bool isRoot)
+    {
+        var tree = MakeTestTree(isUnix);
+
+        var node = tree.FindNode(CreateAbsPath(path, isUnix));
+        node.Should().NotBeNull();
+        node!.IsTreeRoot.Should().Be(isRoot);
+        if (isRoot)
+        {
+            var act = () => node!.Parent;
+            act.Should().Throw<InvalidOperationException>();
+        }
+
+        node!.Root.Path.Should().Be(isUnix ? CreateAbsPath("/", isUnix) : CreateAbsPath("C:/", isUnix));
+    }
+
+    [Theory]
+    [InlineData("/", true, new string[] { })]
+    [InlineData("/file1.txt", true, new string[] { "/foo", "/baz" })]
+    [InlineData("/foo", true, new string[] { "/file1.txt", "/baz" })]
+    [InlineData("/foo/bar/file4.txt", true, new string[] { })]
+    [InlineData("C:/", false, new string[] { })]
+    [InlineData("C:/file1.txt", false, new string[] { "C:/foo", "C:/baz" })]
+    [InlineData("C:/foo", false, new string[] { "C:/file1.txt", "C:/baz" })]
+    [InlineData("C:/foo/bar/file4.txt", false, new string[] { })]
+    public void Test_GetSiblings(string path, bool isUnix, string[] expectedSiblingPaths)
+    {
+        var tree = MakeTestTree(isUnix);
+
+        var node = tree.FindNode(CreateAbsPath(path, isUnix));
+        node.Should().NotBeNull();
+        node!.GetSiblings().Select(x => x.Path).Should()
+            .BeEquivalentTo(expectedSiblingPaths.Select(x => CreateAbsPath(x, isUnix)));
+    }
+
+    [Theory]
+    [InlineData("/", true,
+        new string[]
+            { "/file1.txt", "/foo/file2.txt", "/foo/file3.txt", "/foo/bar/file4.txt", "/baz/bazer/file5.txt" })]
+    [InlineData("/file1.txt", true, new string[] { })]
+    [InlineData("/foo", true, new string[] { "/foo/file2.txt", "/foo/file3.txt", "/foo/bar/file4.txt" })]
+    [InlineData("/foo/file2.txt", true, new string[] { })]
+    [InlineData("/foo/bar", true, new string[] { "/foo/bar/file4.txt" })]
+    [InlineData("/baz", true, new string[] { "/baz/bazer/file5.txt" })]
+    [InlineData("C:/", false,
+        new string[]
+            { "C:/file1.txt", "C:/foo/file2.txt", "C:/foo/file3.txt", "C:/foo/bar/file4.txt", "C:/baz/bazer/file5.txt" })]
+    [InlineData("C:/file1.txt", false, new string[] { })]
+    [InlineData("C:/foo", false, new string[] { "C:/foo/file2.txt", "C:/foo/file3.txt", "C:/foo/bar/file4.txt" })]
+    [InlineData("C:/foo/file2.txt", false, new string[] { })]
+    [InlineData("C:/foo/bar", false, new string[] { "C:/foo/bar/file4.txt" })]
+    [InlineData("C:/baz", false, new string[] { "C:/baz/bazer/file5.txt" })]
+    public void Test_GetAllDescendentFiles(string path, bool isUnix, string[] expectedDescendentPaths)
+    {
+        var tree = MakeTestTree(isUnix);
+
+        var node = tree.FindNode(CreateAbsPath(path, isUnix));
+        node.Should().NotBeNull();
+        node!.GetAllDescendentFiles().Select(x => x.Path).Should()
+            .BeEquivalentTo(expectedDescendentPaths.Select(x => CreateAbsPath(x, isUnix)));
+    }
+
+
+    [Theory]
+    [InlineData("/", true,
+        new string[]
+            { "/file1.txt", "/foo/file2.txt", "/foo/file3.txt", "/foo/bar/file4.txt", "/baz/bazer/file5.txt" })]
+    [InlineData("/file1.txt", true, new string[] { })]
+    [InlineData("/foo", true, new string[] { "/foo/file2.txt", "/foo/file3.txt", "/foo/bar/file4.txt" })]
+    [InlineData("/foo/file2.txt", true, new string[] { })]
+    [InlineData("/foo/bar", true, new string[] { "/foo/bar/file4.txt" })]
+    [InlineData("/baz", true, new string[] { "/baz/bazer/file5.txt" })]
+    [InlineData("C:/", false,
+        new string[]
+            { "C:/file1.txt", "C:/foo/file2.txt", "C:/foo/file3.txt", "C:/foo/bar/file4.txt", "C:/baz/bazer/file5.txt" })]
+    [InlineData("C:/file1.txt", false, new string[] { })]
+    [InlineData("C:/foo", false, new string[] { "C:/foo/file2.txt", "C:/foo/file3.txt", "C:/foo/bar/file4.txt" })]
+    [InlineData("C:/foo/file2.txt", false, new string[] { })]
+    [InlineData("C:/foo/bar", false, new string[] { "C:/foo/bar/file4.txt" })]
+    [InlineData("C:/baz", false, new string[] { "C:/baz/bazer/file5.txt" })]
+    public void Test_GetAllDescendentFilesDictionary(string path, bool isUnix, string[] expectedDescendentPaths)
+    {
+        var tree = MakeTestTree(isUnix);
+
+        var node = tree.FindNode(CreateAbsPath(path, isUnix));
+        node.Should().NotBeNull();
+        node!.GetAllDescendentFilesDictionary().Select(x => x.Key).Should()
+            .BeEquivalentTo(expectedDescendentPaths.Select(x => CreateAbsPath(x, isUnix)));
+    }
+
+    private static FileTreeNode<AbsolutePath, int> MakeTestTree(bool isUnix = true)
+    {
+        Dictionary<AbsolutePath, int> fileEntries;
+        if (isUnix)
+        {
+            fileEntries = new Dictionary<AbsolutePath, int>
+            {
+                { CreateAbsPath("/file1.txt", isUnix), 1 },
+                { CreateAbsPath("/foo/file2.txt", isUnix), 2 },
+                { CreateAbsPath("/foo/file3.txt", isUnix), 3 },
+                { CreateAbsPath("/foo/bar/file4.txt", isUnix), 4 },
+                { CreateAbsPath("/baz/bazer/file5.txt", isUnix), 5 },
+            };
+        }
+        else
+        {
+            fileEntries = new Dictionary<AbsolutePath, int>
+            {
+                { CreateAbsPath("c:/file1.txt", isUnix), 1 },
+                { CreateAbsPath("c:/foo/file2.txt", isUnix), 2 },
+                { CreateAbsPath("c:/foo/file3.txt", isUnix), 3 },
+                { CreateAbsPath("c:/foo/bar/file4.txt", isUnix), 4 },
+                { CreateAbsPath("c:/baz/bazer/file5.txt", isUnix), 5 },
+            };
+        }
+
+        return FileTreeNode<AbsolutePath, int>.CreateTree(fileEntries);
+    }
+
+    private static AbsolutePath CreateAbsPath(string input, bool isUnix = true)
+    {
+        var os = CreateOSInformation(isUnix);
+        var fs = new InMemoryFileSystem(os);
+        var path = AbsolutePath.FromSanitizedFullPath(input, fs);
+        return path;
+    }
+
+    private static IOSInformation CreateOSInformation(bool isUnix)
+    {
+        return isUnix ? new OSInformation(OSPlatform.Linux) : new OSInformation(OSPlatform.Windows);
+    }
+}

--- a/tests/NexusMods.Paths.Tests/FileTree/RelativeFileTreeTests.cs
+++ b/tests/NexusMods.Paths.Tests/FileTree/RelativeFileTreeTests.cs
@@ -1,0 +1,176 @@
+﻿using NexusMods.Paths.FileTree;
+
+namespace NexusMods.Paths.Tests.FileTree;
+
+public class RelativeFileTreeTests
+{
+    [Theory]
+    [InlineData("file1.txt", true, 1)]
+    [InlineData("file2.txt", false, 2)]
+    [InlineData("foo/file2.txt", true, 2)]
+    [InlineData("foo/file3.txt", true, 3)]
+    [InlineData("foo/bar/file4.txt", true, 4)]
+    [InlineData("baz/bazer/file5.txt", true, 5)]
+    public void Test_FindNode(string path, bool found, int value)
+    {
+        var tree = MakeTestTree();
+
+        var node = tree.FindNode((RelativePath)path);
+        if (found)
+        {
+            node.Should().NotBeNull();
+            node!.Path.Should().Be((RelativePath)path);
+            node!.Value.Should().Be(value);
+        }
+        else
+        {
+            node.Should().BeNull();
+        }
+    }
+
+    [Theory]
+    [InlineData("file1.txt", "file1.txt")]
+    [InlineData("foo", "foo")]
+    [InlineData("foo/file2.txt", "file2.txt")]
+    [InlineData("foo/file3.txt", "file3.txt")]
+    [InlineData("foo/bar", "bar")]
+    [InlineData("foo/bar/file4.txt", "file4.txt")]
+    [InlineData("baz/bazer", "bazer")]
+    [InlineData("baz/bazer/file5.txt", "file5.txt")]
+    public void Test_Name(string path, string name)
+    {
+        var tree = MakeTestTree();
+
+        var node = tree.FindNode((RelativePath)path);
+        node.Should().NotBeNull();
+        node!.Name.Should().Be((RelativePath)name);
+    }
+
+    [Theory]
+    [InlineData("file1.txt", true)]
+    [InlineData("foo", false)]
+    [InlineData("foo/file2.txt", true)]
+    [InlineData("foo/file3.txt", true)]
+    [InlineData("foo/bar", false)]
+    [InlineData("foo/bar/file4.txt", true)]
+    [InlineData("baz/bazer", false)]
+    [InlineData("baz/bazer/file5.txt", true)]
+    public void Test_IsFile(string path, bool isFile)
+    {
+        var tree = MakeTestTree();
+
+        var node = tree.FindNode((RelativePath)path);
+        node.Should().NotBeNull();
+        node!.IsFile.Should().Be(isFile);
+    }
+
+    [Theory]
+    [InlineData("", false)]
+    [InlineData("file1.txt", true)]
+    [InlineData("foo", true)]
+    [InlineData("foo/file2.txt", true)]
+    public void Test_HasParent(string path, bool hasParent)
+    {
+        var tree = MakeTestTree();
+
+        var node = tree.FindNode((RelativePath)path);
+        node.Should().NotBeNull();
+        node!.HasParent.Should().Be(hasParent);
+        if (hasParent)
+        {
+            node!.Parent.Should().NotBeNull();
+        }
+    }
+
+    [Theory]
+    [InlineData("", true)]
+    [InlineData("file1.txt", false)]
+    [InlineData("foo", false)]
+    [InlineData("foo/file2.txt", false)]
+    public void Test_IsTreeRoot(string path, bool isRoot)
+    {
+        var tree = MakeTestTree();
+
+        var node = tree.FindNode((RelativePath)path);
+        node.Should().NotBeNull();
+        node!.IsTreeRoot.Should().Be(isRoot);
+        if (isRoot)
+        {
+            var act = () => node!.Parent;
+            act.Should().Throw<InvalidOperationException>();
+        }
+
+        node!.Root.Path.Should().Be("");
+    }
+
+
+    [Theory]
+    [InlineData("", new string[] { })]
+    [InlineData("file1.txt", new string[] { "foo", "baz" })]
+    [InlineData("foo", new string[] { "file1.txt", "baz" })]
+    [InlineData("foo/bar/file4.txt", new string[] { })]
+    public void Test_GetSiblings(string path, string[] expectedSiblingPaths)
+    {
+        var tree = MakeTestTree();
+
+        var node = tree.FindNode((RelativePath)path);
+        node.Should().NotBeNull();
+        node!.GetSiblings().Select(x => x.Path).Should()
+            .BeEquivalentTo(expectedSiblingPaths.Select(x => (RelativePath)x));
+    }
+
+    [Theory]
+    [InlineData("",
+        new string[]
+            { "file1.txt", "foo/file2.txt", "foo/file3.txt", "foo/bar/file4.txt", "baz/bazer/file5.txt" })]
+    [InlineData("file1.txt", new string[] { })]
+    [InlineData("foo", new string[] { "foo/file2.txt", "foo/file3.txt", "foo/bar/file4.txt" })]
+    [InlineData("foo/file2.txt", new string[] { })]
+    [InlineData("foo/bar", new string[] { "foo/bar/file4.txt" })]
+    [InlineData("baz", new string[] { "baz/bazer/file5.txt" })]
+    public void Test_GetAllDescendentFiles(string path, string[] expectedDescendentPaths)
+    {
+        var tree = MakeTestTree();
+
+        var node = tree.FindNode((RelativePath)path);
+        node.Should().NotBeNull();
+        node!.GetAllDescendentFiles().Select(x => x.Path).Should()
+            .BeEquivalentTo(expectedDescendentPaths.Select(x => (RelativePath)x));
+    }
+
+
+    [Theory]
+    [InlineData("",
+        new string[]
+            { "file1.txt", "foo/file2.txt", "foo/file3.txt", "foo/bar/file4.txt", "baz/bazer/file5.txt" })]
+    [InlineData("file1.txt", new string[] { })]
+    [InlineData("foo", new string[] { "foo/file2.txt", "foo/file3.txt", "foo/bar/file4.txt" })]
+    [InlineData("foo/file2.txt", new string[] { })]
+    [InlineData("foo/bar", new string[] { "foo/bar/file4.txt" })]
+    [InlineData("baz", new string[] { "baz/bazer/file5.txt" })]
+    public void Test_GetAllDescendentFilesDictionary(string path, string[] expectedDescendentPaths)
+    {
+        var tree = MakeTestTree();
+
+        var node = tree.FindNode((RelativePath)path);
+        node.Should().NotBeNull();
+        node!.GetAllDescendentFilesDictionary().Select(x => x.Key).Should()
+            .BeEquivalentTo(expectedDescendentPaths.Select(x => (RelativePath)x));
+    }
+
+    private static FileTreeNode<RelativePath, int> MakeTestTree()
+    {
+        Dictionary<RelativePath, int> fileEntries;
+
+        fileEntries = new Dictionary<RelativePath, int>
+        {
+            { new RelativePath("file1.txt"), 1 },
+            { new RelativePath("foo/file2.txt"), 2 },
+            { new RelativePath("foo/file3.txt"), 3 },
+            { new RelativePath("foo/bar/file4.txt"), 4 },
+            { new RelativePath("baz/bazer/file5.txt"), 5 },
+        };
+
+        return FileTreeNode<RelativePath, int>.CreateTree(fileEntries);
+    }
+}

--- a/tests/NexusMods.Paths.Tests/RelativePathTests.cs
+++ b/tests/NexusMods.Paths.Tests/RelativePathTests.cs
@@ -252,6 +252,42 @@ public class RelativePathTests
     }
 
     [Theory]
+    [InlineData("", "", true)]
+    [InlineData("", "foo", false)]
+    [InlineData("foo", "bar", false)]
+    [InlineData("foo", "", true)]
+    [InlineData("foo/bar/baz", "", true)]
+    [InlineData("foo/bar/baz", "foo", true)]
+    [InlineData("foo/bar/baz", "foo/bar", true)]
+    [InlineData("foobar", "foo", false)]
+    [InlineData("foo/bar/baz", "foo/baz", false)]
+    public void Test_StartsWithRelative(string child, string parent, bool expected)
+    {
+        var childPath = (RelativePath)child;
+        var parentPath = (RelativePath)parent;
+        var actual = childPath.StartsWith(parentPath);
+        actual.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("", "", true)]
+    [InlineData("", "foo", false)]
+    [InlineData("foo", "bar", false)]
+    [InlineData("foo", "", true)]
+    [InlineData("foo/bar/baz", "", true)]
+    [InlineData("foo/bar/baz", "bar/baz", true)]
+    [InlineData("foo/bar/baz", "foo/bar/baz", true)]
+    [InlineData("foobar", "bar", false)]
+    [InlineData("foo/bar/baz", "foo/baz", false)]
+    public void Test_EndsWithRelative(string child, string parent, bool expected)
+    {
+        var childPath = (RelativePath)child;
+        var parentPath = (RelativePath)parent;
+        var actual = childPath.EndsWith(parentPath);
+        actual.Should().Be(expected);
+    }
+
+    [Theory]
     [InlineData("foo/bar/baz", 0, "foo/bar/baz")]
     [InlineData("foo/bar/baz", 1, "bar/baz")]
     [InlineData("foo/bar/baz", 2, "baz")]

--- a/tests/NexusMods.Paths.Tests/RelativePathTests.cs
+++ b/tests/NexusMods.Paths.Tests/RelativePathTests.cs
@@ -8,7 +8,7 @@ public class RelativePathTests
     {
         return isUnix ? OSInformation.FakeUnix : OSInformation.FakeWindows;
     }
-    
+
     [Theory]
     [InlineData("a", "a")]
     [InlineData("a/b", "a/b")]
@@ -32,8 +32,8 @@ public class RelativePathTests
         var path = basePath.Combine(input).RelativeTo(basePath);
         path.ToString().Should().Be(expected);
     }
-    
-    
+
+
     [Theory]
     [InlineData("a", "a")]
     [InlineData("a/", "a")]
@@ -45,11 +45,10 @@ public class RelativePathTests
         string inputPath,
         string expectedRelativePath)
     {
-        
         var sanitizedPath = RelativePath.FromUnsanitizedInput(inputPath);
         sanitizedPath.Should().Be(expectedRelativePath);
     }
-    
+
     [Theory]
     [InlineData(true, "", "")]
     [InlineData(false, "", "")]
@@ -58,9 +57,19 @@ public class RelativePathTests
     public void Test_ToNativeSeparators(bool isUnix, string input, string expected)
     {
         var os = CreateOSInformation(isUnix);
-        
+
         var path = new RelativePath(input);
         path.ToNativeSeparators(os).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("foo", "foo")]
+    [InlineData("foo/bar", "bar")]
+    public void Test_Name(string input, string expected)
+    {
+        var path = new RelativePath(input);
+        path.Name.Should().Be(expected);
     }
 
     [Theory]
@@ -117,6 +126,60 @@ public class RelativePathTests
     }
 
     [Theory]
+    [InlineData("", "")]
+    [InlineData("foo", "")]
+    [InlineData("foo/bar", "")]
+    [InlineData("foo/bar/baz", "")]
+    public void Test_GetRootComponent(string input, string expectedRootComponent)
+    {
+        var path = new RelativePath(input);
+        path.GetRootComponent.Should().Be(expectedRootComponent);
+    }
+
+    [Theory]
+    [InlineData("", new string[] { })]
+    [InlineData("foo", new string[] { "foo" })]
+    [InlineData("foo/bar", new string[] { "foo", "bar" })]
+    [InlineData("foo/bar/baz", new string[] { "foo", "bar", "baz" })]
+    public void Test_Parts(string input, string[] expectedParts)
+    {
+        var path = new RelativePath(input);
+        path.Parts.Should().BeEquivalentTo(expectedParts.Select(x => new RelativePath(x)));
+    }
+
+    [Theory]
+    [InlineData("", new string[] { })]
+    [InlineData("foo", new string[] { "foo" })]
+    [InlineData("foo/bar", new string[] { "foo/bar", "foo" })]
+    [InlineData("foo/bar/baz", new string[] { "foo/bar/baz", "foo/bar", "foo" })]
+    public void Test_GetAllParents(string input, string[] expectedParts)
+    {
+        var path = new RelativePath(input);
+        path.GetAllParents().Should().BeEquivalentTo(expectedParts.Select(x => new RelativePath(x)));
+    }
+
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("foo", "foo")]
+    [InlineData("foo/bar", "foo/bar")]
+    [InlineData("foo/bar/baz", "foo/bar/baz")]
+    public void Test_GetNonRootPart(string input, string expected)
+    {
+        var path = new RelativePath(input);
+        path.GetNonRootPart().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("", false)]
+    [InlineData("foo", false)]
+    [InlineData("foo/bar", false)]
+    public void Test_IsRooted(string input, bool expected)
+    {
+        var path = new RelativePath(input);
+        path.IsRooted.Should().Be(expected);
+    }
+
+    [Theory]
     [InlineData("foo", ".txt", "foo.txt")]
     [InlineData("foo.txt", ".md", "foo.md")]
     public void Test_ReplaceExtension(string input, string extension, string expectedOutput)
@@ -161,7 +224,7 @@ public class RelativePathTests
         var actual = path.StartsWith(right);
         actual.Should().Be(expected);
     }
-    
+
     [Theory]
     [InlineData("foo", "bar", false)]
     [InlineData("foo", "foo", true)]
@@ -203,6 +266,7 @@ public class RelativePathTests
     [Theory]
     [InlineData("foo/bar/baz", "foo", "bar/baz")]
     [InlineData("foo/bar/baz", "foo/bar", "baz")]
+    [InlineData("foo/bar/baz", "foo/bar/baz", "")]
     public void Test_RelativeTo(string left, string right, string expectedOutput)
     {
         var leftPath = new RelativePath(left);


### PR DESCRIPTION
This PR adds abstractions for file trees, as detailed in this issue: https://github.com/Nexus-Mods/NexusMods.App/issues/553

- The `IFileTree` interface defines a set of common functionalities. 
- `FileTreeNode<TPath, TValue>` defines a generic implementation of `IFileTree`, where the contained paths are Type agnostic and where each File entry contains an associated generic TValue.
 
To allow `FileTreeNode` to be path agnostic a new `IPath<TConcretePath>` was added, with the intent have it be be implemented by `AbsolutePath`, `RelativePath` and `GamePath`.

The main objective of this new interface is to define a set of common functionality for path types, while still allowing these methods to return concrete path types instead of `IPath`.

The problem with using `IPath` directly are Boxing allocations, since all Path types are implemented through structs.

To avoid any boxing/unboxing, the code had to heavily rely on generics, making sure to always reference concrete types rather than interfaces.

A limited number of common methods where added to `IPath<TConcretePath>`, but this quickly revealed a number of inconsistencies between `AbsolutePath` and `RelativePath`.
Most of these come from the special handling that Root folders require.

It should be noted that trying to deal with them in an abstracted way was quite frustrating. Each type has its own set of methods, only some of them implemented on both types, without a common interface to define them and with some of them having different meanings or semantics.
All the common functionality is in PathHelpers, which only deals with strings and requires an OS object for each method, making using it very unwieldy.
There is an open issue for this here: https://github.com/Nexus-Mods/NexusMods.Paths/issues/10


