### PR TITLE
Add deconstruction to FileTreeNode for cleaner tests

### DIFF
--- a/src/NexusMods.Paths/FileTree/FileTreeNode.cs
+++ b/src/NexusMods.Paths/FileTree/FileTreeNode.cs
@@ -189,6 +189,18 @@ public class FileTreeNode<TPath, TValue> : IFileTree<FileTreeNode<TPath, TValue>
         return rootNode;
     }
 
+
+    /// <summary>
+    /// Deconstructs the node into its path and value.
+    /// </summary>
+    /// <param name="path"></param>
+    /// <param name="value"></param>
+    public void Deconstruct(out TPath path, out TValue? value)
+    {
+        path = Path;
+        value = Value;
+    }
+
     /// <summary>
     /// Populates the tree with the given collection of file entries.
     /// </summary>

--- a/tests/NexusMods.Paths.Tests/FileTree/AbsoluteFileTreeTests.cs
+++ b/tests/NexusMods.Paths.Tests/FileTree/AbsoluteFileTreeTests.cs
@@ -28,8 +28,9 @@ public class AbsoluteFileTreeTests
         if (found)
         {
             node.Should().NotBeNull();
-            node!.Path.Should().Be(CreateAbsPath(path, isUnix));
-            node!.Value.Should().Be(value);
+            var (testPath, testValue) = node!;
+            testPath.Should().Be(CreateAbsPath(path, isUnix));
+            testValue.Should().Be(value);
         }
         else
         {

--- a/tests/NexusMods.Paths.Tests/FileTree/RelativeFileTreeTests.cs
+++ b/tests/NexusMods.Paths.Tests/FileTree/RelativeFileTreeTests.cs
@@ -19,8 +19,9 @@ public class RelativeFileTreeTests
         if (found)
         {
             node.Should().NotBeNull();
-            node!.Path.Should().Be((RelativePath)path);
-            node!.Value.Should().Be(value);
+            var (testPath, testValue) = node!;
+            testPath.Should().Be((RelativePath)path);
+            testValue.Should().Be(value);
         }
         else
         {


### PR DESCRIPTION
Updated FileTreeNode class to include Deconstruct method, enabling more readable testing of path and value. Changes have been applied to both Absolute and Relative FileTreeTests. Deconstruction simplifies asserting equalities and improves overall code readability in tests.