### PR TITLE
Fix `.Parts`

### DIFF
--- a/tests/NexusMods.Paths.Tests/AbsolutePathTests.cs
+++ b/tests/NexusMods.Paths.Tests/AbsolutePathTests.cs
@@ -94,7 +94,8 @@ public class AbsolutePathTests
     {
         var path = CreatePath(input, isUnix);
         var actualParts = path.Parts;
-        actualParts.Should().BeEquivalentTo(expectedParts.Select(p => new RelativePath(p)));
+        actualParts.Should().BeEquivalentTo(expectedParts.Select(p => new RelativePath(p)),
+            opts => opts.WithStrictOrdering());
     }
 
     [Theory]

--- a/tests/NexusMods.Paths.Tests/RelativePathTests.cs
+++ b/tests/NexusMods.Paths.Tests/RelativePathTests.cs
@@ -144,7 +144,8 @@ public class RelativePathTests
     public void Test_Parts(string input, string[] expectedParts)
     {
         var path = new RelativePath(input);
-        path.Parts.Should().BeEquivalentTo(expectedParts.Select(x => new RelativePath(x)));
+        path.Parts.Should().BeEquivalentTo(expectedParts.Select(x => new RelativePath(x)),
+            opts => opts.WithStrictOrdering());
     }
 
     [Theory]


### PR DESCRIPTION
RelativePath.Parts was returning the wrong value, this is because we were using an interator correctly and walking from the tail of the path to the head. This wasn't caught by our tests because they didn't have Strict Ordering enabled on the Fluent check. Fixed the tests, reimplemented `.Parts` to fix the bug. 