### PR TITLE
Restore Benchmark Functionality & Improve FileTree GetAllDescendantFiles

### DIFF
--- a/NexusMods.Paths.sln
+++ b/NexusMods.Paths.sln
@@ -30,6 +30,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Paths.Tests", "te
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Paths.TestingHelpers", "src\NexusMods.Paths.TestingHelpers\NexusMods.Paths.TestingHelpers.csproj", "{FABE9B73-49FF-472C-9013-F52876F25E1D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Paths.Benchmarks", "src\NexusMods.Paths.Benchmarks\NexusMods.Paths.Benchmarks.csproj", "{E86B44A1-D57E-4B0B-8F62-869E1784C49C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,7 @@ Global
 		{A92DED3D-BC67-4E04-9A06-9A1B302B3070} = {0377EBE6-F147-4233-86AD-32C821B9567E}
 		{30CBEB4A-E0C0-4B11-A0CF-F97BFACEEF89} = {6ED01F9D-5E12-4EB2-9601-64A2ADC719DE}
 		{FABE9B73-49FF-472C-9013-F52876F25E1D} = {0377EBE6-F147-4233-86AD-32C821B9567E}
+		{E86B44A1-D57E-4B0B-8F62-869E1784C49C} = {0377EBE6-F147-4233-86AD-32C821B9567E}
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A92DED3D-BC67-4E04-9A06-9A1B302B3070}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -53,5 +56,9 @@ Global
 		{FABE9B73-49FF-472C-9013-F52876F25E1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FABE9B73-49FF-472C-9013-F52876F25E1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FABE9B73-49FF-472C-9013-F52876F25E1D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E86B44A1-D57E-4B0B-8F62-869E1784C49C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E86B44A1-D57E-4B0B-8F62-869E1784C49C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E86B44A1-D57E-4B0B-8F62-869E1784C49C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E86B44A1-D57E-4B0B-8F62-869E1784C49C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/NexusMods.Paths.Benchmarks/Assets.cs
+++ b/src/NexusMods.Paths.Benchmarks/Assets.cs
@@ -1,0 +1,12 @@
+using System.IO;
+
+namespace NexusMods.Paths.Benchmarks;
+
+public class Assets
+{
+    public static string ProgramFolder => FileSystem.Shared.GetKnownPath(KnownPath.EntryDirectory).ToString();
+    public static string AssetsFolder => Path.Combine(ProgramFolder, "Assets");
+    // ReSharper disable once InconsistentNaming
+    public static string Sample7zFile => Path.Combine(AssetsFolder, "data_7zip_lzma2.7z");
+    public static string SampleZipFile => Path.Combine(AssetsFolder, "data_zip_lzma.zip");
+}

--- a/src/NexusMods.Paths.Benchmarks/Benchmarks/ChangeCase.cs
+++ b/src/NexusMods.Paths.Benchmarks/Benchmarks/ChangeCase.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using NexusMods.Paths.Benchmarks.Interfaces;
+using NexusMods.Paths.HighPerformance.Backports.System.Globalization;
+
+namespace NexusMods.Paths.Benchmarks.Benchmarks;
+
+[SkipLocalsInit]
+[MemoryDiagnoser]
+[BenchmarkInfo("Change Case", "Tests the performance of changing the case on a string.")]
+public class ChangeCase : IBenchmark
+{
+    [Params(4, 16, 64, 256, 1024)]
+    // ReSharper disable once UnusedAutoPropertyAccessor.Global
+    public int StringLength { get; set; }
+
+    private static Random _random = new();
+    private string _value = null!;
+    private string _valueEmoji = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _value = RandomStringUpper(StringLength);
+        _valueEmoji = RandomStringUpperWithEmoji(StringLength);
+    }
+
+    [Benchmark]
+    public void Runtime_Current_NonAscii()
+    {
+        Span<char> buffer = stackalloc char[_valueEmoji.Length];
+        MemoryExtensions.ToLowerInvariant(_valueEmoji, buffer);
+    }
+
+    [Benchmark(Baseline = true)]
+    public void Runtime_Current()
+    {
+        Span<char> buffer = stackalloc char[_value.Length];
+        MemoryExtensions.ToLowerInvariant(_value, buffer);
+    }
+
+    [Benchmark]
+    public void NET8_Backport()
+    {
+        Span<char> buffer = stackalloc char[_value.Length];
+        TextInfo.ChangeCase<TextInfo.ToLowerConversion>(_value, buffer);
+    }
+
+    [Benchmark]
+    public void NET8_Backport_NonAscii()
+    {
+        Span<char> buffer = stackalloc char[_valueEmoji.Length];
+        TextInfo.ChangeCase<TextInfo.ToLowerConversion>(_valueEmoji, buffer);
+    }
+
+    private static string RandomString(int length, string charSet)
+    {
+        return new string(Enumerable.Repeat(charSet, length)
+            .Select(s => s[_random.Next(s.Length)]).ToArray());
+    }
+
+    private static string RandomStringUpper(int length) => RandomString(length, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+
+    private static string RandomStringUpperWithEmoji(int length) => RandomString(length, "ABCDEFGHIJKLMNOPQRSTUVWXYZ⚠️🚦🔺🏒😕🏞🖌🖕🌷☠⛩🍸👳🍠🚦📟💦🚏🌥🏪🌖😱");
+}

--- a/src/NexusMods.Paths.Benchmarks/Benchmarks/ChangeCaseVsOrdinalIgnoreCase.cs
+++ b/src/NexusMods.Paths.Benchmarks/Benchmarks/ChangeCaseVsOrdinalIgnoreCase.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using NexusMods.Paths.Benchmarks.Interfaces;
+using NexusMods.Paths.HighPerformance.Backports.System.Globalization;
+
+namespace NexusMods.Paths.Benchmarks.Benchmarks;
+
+[MemoryDiagnoser]
+[BenchmarkInfo("Change Case + Ordinal vs OrdinalIgnoreCase", "Compares Change Case + Ordinal vs OrdinalIgnoreCase")]
+public class ChangeCaseVsOrdinalIgnoreCase : IBenchmark
+{
+    [Params(4, 16, 64, 256, 1024)]
+    // ReSharper disable once UnusedAutoPropertyAccessor.Global
+    public int StringLength { get; set; }
+
+    private string _value1 = null!;
+    private string _value2 = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _value1 = RandomStringUpper(StringLength);
+        _value2 = _value1 + "_";
+    }
+
+    [Benchmark(Baseline = true)]
+    public bool WithOrdinalIgnoreCase()
+    {
+        return string.Equals(_value1, _value2, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Benchmark]
+    public bool WithChangeCaseOrdinal()
+    {
+        var span1 = _value1.Length > 512
+            ? GC.AllocateUninitializedArray<char>(_value1.Length)
+            : stackalloc char[_value1.Length];
+        TextInfo.ChangeCase<TextInfo.ToLowerConversion>(_value1, span1);
+
+        var span2 = _value1.Length > 512
+            ? GC.AllocateUninitializedArray<char>(_value2.Length)
+            : stackalloc char[_value2.Length];
+        TextInfo.ChangeCase<TextInfo.ToLowerConversion>(_value2, span2);
+
+        return span1.SequenceEqual(span2);
+    }
+
+    private static string RandomString(int length, string charSet)
+    {
+        return new string(Enumerable.Repeat(charSet, length)
+            .Select(s => s[Random.Shared.Next(s.Length)]).ToArray());
+    }
+
+    private static string RandomStringUpper(int length) => RandomString(length, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+}

--- a/src/NexusMods.Paths.Benchmarks/Benchmarks/DelegateAllocationCost.cs
+++ b/src/NexusMods.Paths.Benchmarks/Benchmarks/DelegateAllocationCost.cs
@@ -1,0 +1,55 @@
+using System;
+using BenchmarkDotNet.Attributes;
+using NexusMods.Paths.Benchmarks.Interfaces;
+
+namespace NexusMods.Paths.Benchmarks.Benchmarks;
+
+[MemoryDiagnoser]
+[BenchmarkInfo("Delegate Allocation Cost", "Compares the cost of delegates using various methods")]
+public class DelegateAllocationCost : IBenchmark
+{
+    private readonly int _valueType;
+    private readonly string _referenceType;
+
+    public DelegateAllocationCost()
+    {
+        _valueType = Random.Shared.Next();
+        _referenceType = Guid.NewGuid().ToString("N");
+    }
+
+    [Benchmark]
+    public string NoState_ReferenceType()
+    {
+        return NoState(() => _referenceType);
+    }
+
+    [Benchmark]
+    public int NoState_ValueType()
+    {
+        return NoState(() => _valueType * 2);
+    }
+
+    [Benchmark]
+    public string WithRefState_ReferenceType()
+    {
+        return WithRefState((ref string state) => state, _referenceType);
+    }
+
+    [Benchmark]
+    public int WithRefState_ValueType()
+    {
+        return WithRefState((ref int state) => state * 2, _valueType);
+    }
+
+    private static TOut NoState<TOut>(Func<TOut> act)
+    {
+        return act();
+    }
+
+    private static TOut WithRefState<TState, TOut>(FuncRef<TState, TOut> act, TState state)
+    {
+        return act(ref state);
+    }
+
+    private delegate TOut FuncRef<TState, out TOut>(ref TState state);
+}

--- a/src/NexusMods.Paths.Benchmarks/Benchmarks/EnumerateFiles.cs
+++ b/src/NexusMods.Paths.Benchmarks/Benchmarks/EnumerateFiles.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using NexusMods.Paths.Benchmarks.Interfaces;
+
+namespace NexusMods.Paths.Benchmarks.Benchmarks;
+
+[MemoryDiagnoser]
+[BenchmarkInfo("File Enumeration", "Tests the performance of fetching all files from a directory.")]
+public class EnumerateFiles : IBenchmark
+{
+    public EnumerateFiles()
+    {
+        var fileSystem = FileSystem.Shared;
+        FilePath = fileSystem.GetKnownPath(KnownPath.ApplicationDataDirectory);
+    }
+
+    // Placeholder path that'll probably work for people using Windows.
+    // Point this at your games' directory.
+    public AbsolutePath FilePath { get; }
+
+    // Note: Tests are written using 'foreach' to provide more accurate memory measurements
+    //       ToArray leads to extra allocation.
+
+    [Benchmark]
+    public AbsolutePath EnumerateFiles_New()
+    {
+        var paths = FilePath.EnumerateFiles();
+        AbsolutePath result = default;
+        foreach (var path in paths)
+            result = path;
+
+        return result;
+    }
+
+    [Benchmark]
+    public AbsolutePath EnumerateFiles_Old()
+    {
+        var paths = OriginalImplementation.EnumerateFiles(FilePath);
+        AbsolutePath result = default;
+        foreach (var path in paths)
+            result = path;
+
+        return result;
+    }
+
+    [Benchmark]
+    public AbsolutePath EnumerateDirectories_New()
+    {
+        var paths = FileSystem.Shared.EnumerateDirectories(FilePath);
+        AbsolutePath result = default;
+        foreach (var path in paths)
+            result = path;
+
+        return result;
+    }
+
+    [Benchmark]
+    public AbsolutePath EnumerateDirectories_Old()
+    {
+        var paths = OriginalImplementation.EnumerateDirectories(FilePath);
+        AbsolutePath result = default;
+        foreach (var path in paths)
+            result = path;
+
+        return result;
+    }
+
+    [Benchmark]
+    public IFileEntry? EnumerateFileEntries_New()
+    {
+        var entries = FilePath.EnumerateFileEntries();
+        IFileEntry? result = default;
+        foreach (var entry in entries)
+            result = entry;
+
+        return result;
+    }
+
+    // [Benchmark]
+    // public IFileEntry? EnumerateFileEntries_Old()
+    // {
+    //     var entries = OriginalImplementation.EnumerateFileEntries(FilePath);
+    //     IFileEntry? result = default;
+    //     foreach (var entry in entries)
+    //         result = entry;
+    //
+    //     return result;
+    // }
+
+    #region Original Implementation
+
+    private struct OriginalImplementation
+    {
+        public static IEnumerable<AbsolutePath> EnumerateFiles(AbsolutePath path, string pattern = "*", bool recursive = true)
+        {
+            return Directory.EnumerateFiles(path.GetFullPath(), pattern,
+                    new EnumerationOptions()
+                    {
+                        AttributesToSkip = 0,
+                        RecurseSubdirectories = recursive,
+                        MatchType = MatchType.Win32
+                    })
+                .Select(file => FileSystem.Shared.FromUnsanitizedFullPath(file));
+        }
+
+        public static IEnumerable<AbsolutePath> EnumerateDirectories(AbsolutePath path, bool recursive = true)
+        {
+            if (!path.DirectoryExists())
+                return Array.Empty<AbsolutePath>();
+
+            return Directory.EnumerateDirectories(path.GetFullPath(), "*",
+                    new EnumerationOptions()
+                    {
+                        AttributesToSkip = 0,
+                        RecurseSubdirectories = recursive,
+                        MatchType = MatchType.Win32
+                    })
+                .Select(file => FileSystem.Shared.FromUnsanitizedFullPath(file));
+        }
+
+        // public static IEnumerable<FileEntry> EnumerateFileEntries(AbsolutePath path, string pattern = "*",
+        //     bool recursive = true)
+        // {
+        //     if (!path.DirectoryExists()) return Array.Empty<FileEntry>();
+        //     return Directory.EnumerateFiles(path.GetFullPath(), pattern,
+        //             new EnumerationOptions()
+        //             {
+        //                 AttributesToSkip = 0,
+        //                 RecurseSubdirectories = recursive,
+        //                 MatchType = MatchType.Win32
+        //             })
+        //         .Select(file =>
+        //         {
+        //             var absPath = file.ToAbsolutePath();
+        //             var info = absPath.FileInfo;
+        //             return new FileEntry(Path: absPath, Size: info.Size, LastModified: info.LastWriteTimeUtc);
+        //         });
+        // }
+    }
+    #endregion
+}

--- a/src/NexusMods.Paths.Benchmarks/Benchmarks/FileTreeGetDescendants.cs
+++ b/src/NexusMods.Paths.Benchmarks/Benchmarks/FileTreeGetDescendants.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using NexusMods.Paths.Benchmarks.Interfaces;
+using NexusMods.Paths.FileTree;
+
+namespace NexusMods.Paths.Benchmarks.Benchmarks;
+
+[MemoryDiagnoser]
+[BenchmarkInfo("Improved File Tree Get Descendants", "Improved Version of GetDescendants for FileTree")]
+public class FileTreeGetDescendants : IBenchmark
+{
+    private readonly FileTreeNode<RelativePath, int> _files;
+
+    public FileTreeGetDescendants()
+    {
+        var files = Directory.GetFiles(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "*", SearchOption.AllDirectories);
+        Console.WriteLine("Files: " + files.Length);
+        var entries = files.ToDictionary(x => new RelativePath(x.TrimStart('/')), x => x.Length);
+        _files = FileTreeNode<RelativePath, int>.CreateTree(entries);
+    }
+
+    // We must enumerate the results to ensure we're not just returning a lazy enumerable.
+    [Benchmark]
+    public List<FileTreeNode<RelativePath, int>> GetDescendants()
+    {
+        return _files.GetAllDescendentFiles();
+    }
+
+    [Benchmark]
+    public List<FileTreeNode<RelativePath, int>> OriginalGetDescendants()
+    {
+        return GetAllDescendentFilesOriginal(_files).ToList();
+    }
+
+    // Original Implementation
+    public IEnumerable<FileTreeNode<TPath, TValue>> GetAllDescendentFilesOriginal<TPath, TValue>(FileTreeNode<TPath, TValue> node) where TPath : struct, IPath<TPath>, IEquatable<TPath>
+    {
+        if (node.IsFile) return Enumerable.Empty<FileTreeNode<TPath, TValue>>();
+        if (!node.Children.Any()) return Enumerable.Empty<FileTreeNode<TPath, TValue>>();
+
+        return node.Children.Values.SelectMany(x => { return x.IsFile ? new[] { x } : GetAllDescendentFilesOriginal(x); });
+    }
+}

--- a/src/NexusMods.Paths.Benchmarks/Benchmarks/Paths.cs
+++ b/src/NexusMods.Paths.Benchmarks/Benchmarks/Paths.cs
@@ -1,0 +1,133 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using NexusMods.Paths.Benchmarks.Interfaces;
+using NexusMods.Paths.Utilities;
+
+namespace NexusMods.Paths.Benchmarks.Benchmarks;
+
+[BenchmarkInfo("Paths", "Comparison between our internal path routines and their closest .NET Path.* methods")]
+[MemoryDiagnoser]
+public class Paths : IBenchmark
+{
+    private readonly string _shortPath;
+    private readonly string[] _paths;
+    private readonly AbsolutePath _nexusShortPath;
+
+    public Paths()
+    {
+        var longPath = @"c:\" + string.Join(@"\", Enumerable.Range(0, 20).Select(x => $"path_{x}"));
+        var shortestPath = @"c:\foo";
+        _shortPath = @"c:\foo\bar\baz";
+        _nexusShortPath = FileSystem.Shared.FromUnsanitizedFullPath(_shortPath);
+        var cPath = @"c:\";
+
+        _paths = new[] { longPath, _shortPath, shortestPath, cPath };
+    }
+
+    public IEnumerable<(string StringPath, AbsolutePath AbsolutePath)> AllPaths =>
+        _paths.Select(p => (p, FileSystem.Shared.FromUnsanitizedFullPath(p)));
+
+    [ParamsSource(nameof(AllPaths))]
+    // ReSharper disable once UnusedAutoPropertyAccessor.Global
+    public (string StringPath, AbsolutePath AbsolutePath) CurrentPath { get; set; }
+
+    [Benchmark]
+    public string SystemGetExtension()
+    {
+        return Path.GetExtension(CurrentPath.StringPath);
+    }
+
+    [Benchmark]
+    public Extension NexusGetExtension()
+    {
+        return CurrentPath.AbsolutePath.Extension;
+    }
+
+    [Benchmark]
+    public string SystemChangeExtension()
+    {
+        return Path.ChangeExtension(CurrentPath.StringPath, ".zip");
+    }
+
+    [Benchmark]
+    public AbsolutePath NexusChangeExtension()
+    {
+        return CurrentPath.AbsolutePath.ReplaceExtension(KnownExtensions.Zip);
+    }
+
+    [Benchmark]
+    public string SystemGetParent()
+    {
+        return Path.GetDirectoryName(CurrentPath.StringPath)!;
+    }
+
+    [Benchmark]
+    public AbsolutePath NexusGetParent()
+    {
+        return CurrentPath.AbsolutePath.Parent;
+    }
+
+    [Benchmark]
+    public bool SystemFileExists()
+    {
+        return File.Exists(CurrentPath.StringPath);
+    }
+
+    [Benchmark]
+    public bool NexusFileExists()
+    {
+        return CurrentPath.AbsolutePath.FileExists;
+    }
+
+    [Benchmark]
+    public string SystemJoinSmall()
+    {
+        return Path.Combine(CurrentPath.StringPath, "foo");
+    }
+
+    [Benchmark]
+    public AbsolutePath NexusJoinSmall()
+    {
+        // Not a fair test here since one is a string concat; other includes
+        // normalization to OS path.
+        return CurrentPath.AbsolutePath.Combine("foo");
+    }
+
+    [Benchmark]
+    public string SystemJoinLarge()
+    {
+        return Path.Combine(CurrentPath.StringPath, "foo/bar/baz/qux/qax");
+    }
+
+    [Benchmark]
+    public AbsolutePath NexusJoinLarge()
+    {
+        return CurrentPath.AbsolutePath.Combine("foo/bar/baz/quz/qax");
+    }
+
+    [Benchmark]
+    public int SystemHash()
+    {
+        return CurrentPath.StringPath.GetHashCode();
+    }
+
+    [Benchmark]
+    public int NexusHash()
+    {
+        return CurrentPath.AbsolutePath.GetHashCode();
+    }
+
+    [Benchmark]
+    public bool SystemEquals()
+    {
+        return CurrentPath.StringPath.Equals(_shortPath);
+    }
+
+    [Benchmark]
+    public bool NexusEquals()
+    {
+        return CurrentPath.AbsolutePath.Equals(_nexusShortPath);
+    }
+}

--- a/src/NexusMods.Paths.Benchmarks/Benchmarks/VectorisedStringHash.cs
+++ b/src/NexusMods.Paths.Benchmarks/Benchmarks/VectorisedStringHash.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Linq;
+using System.Numerics;
+using BenchmarkDotNet.Attributes;
+using NexusMods.Paths.Benchmarks.Interfaces;
+using NexusMods.Paths.Extensions;
+
+// ReSharper disable RedundantAssignment
+
+namespace NexusMods.Paths.Benchmarks.Benchmarks;
+
+[BenchmarkInfo("String Hash", "Tests speed of string hashing algorithm.")]
+public class VectorisedStringHash : IBenchmark
+{
+    private const int ItemCount = 10000;
+
+    [Params(12, 64, 96, 128, 256, 1024)]
+    // ReSharper disable once UnusedAutoPropertyAccessor.Global
+    public int CharacterCount { get; set; }
+
+    public string[] Input { get; set; } = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Input = new string[ItemCount];
+
+        for (var x = 0; x < ItemCount; x++)
+            Input[x] = RandomString(CharacterCount);
+    }
+
+    [Benchmark]
+    public int Custom()
+    {
+        var result = 0;
+        var maxLen = Input.Length / 4;
+        // unroll
+        for (var x = 0; x < maxLen; x += 4)
+        {
+            result = StringExtensions.GetNonRandomizedHashCode32(Input.DangerousGetReferenceAt(x));
+            result = StringExtensions.GetNonRandomizedHashCode32(Input.DangerousGetReferenceAt(x + 1));
+            result = StringExtensions.GetNonRandomizedHashCode32(Input.DangerousGetReferenceAt(x + 2));
+            result = StringExtensions.GetNonRandomizedHashCode32(Input.DangerousGetReferenceAt(x + 3));
+        }
+
+        return result;
+    }
+
+    [Benchmark]
+    public int Runtime_NonRandom_NET702()
+    {
+        var result = 0;
+        var maxLen = Input.Length / 4;
+        // unroll
+        for (var x = 0; x < maxLen; x += 4)
+        {
+            result = Runtime_70_Impl(Input.DangerousGetReferenceAt(x));
+            result = Runtime_70_Impl(Input.DangerousGetReferenceAt(x + 1));
+            result = Runtime_70_Impl(Input.DangerousGetReferenceAt(x + 2));
+            result = Runtime_70_Impl(Input.DangerousGetReferenceAt(x + 3));
+        }
+
+        return result;
+    }
+
+    [Benchmark]
+    public int Runtime_Current()
+    {
+        var result = 0;
+        var maxLen = Input.Length / 4;
+        // unroll
+        for (var x = 0; x < maxLen; x += 4)
+        {
+            result = Input.DangerousGetReferenceAt(x).GetHashCode();
+            result = Input.DangerousGetReferenceAt(x + 1).GetHashCode();
+            result = Input.DangerousGetReferenceAt(x + 2).GetHashCode();
+            result = Input.DangerousGetReferenceAt(x + 3).GetHashCode();
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Implementation from .NET 7.0
+    /// </summary>
+    /// <param name="text"></param>
+    /// <returns></returns>
+    private unsafe int Runtime_70_Impl(ReadOnlySpan<char> text)
+    {
+        fixed (char* src = &text.GetPinnableReference())
+        {
+            // Asserts here for alignment etc. are no longer valid as we are operating on a slice, so memory alignment is not guaranteed.
+            uint hash1 = (5381 << 16) + 5381;
+            var hash2 = hash1;
+
+            var ptr = (uint*)src;
+            var length = text.Length;
+
+            while (length > 2)
+            {
+                length -= 4;
+                // Where length is 4n-1 (e.g. 3,7,11,15,19) this additionally consumes the null terminator
+                hash1 = (BitOperations.RotateLeft(hash1, 5) + hash1) ^ ptr[0];
+                hash2 = (BitOperations.RotateLeft(hash2, 5) + hash2) ^ ptr[1];
+                ptr += 2;
+            }
+
+            if (length > 0)
+            {
+                // Where length is 4n-3 (e.g. 1,5,9,13,17) this additionally consumes the null terminator
+                hash2 = (BitOperations.RotateLeft(hash2, 5) + hash2) ^ ptr[0];
+            }
+
+            return (int)(hash1 + (hash2 * 1566083941));
+        }
+    }
+
+    private static Random _random = new Random();
+    private static string RandomString(int length)
+    {
+        const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        return new string(Enumerable.Repeat(chars, length)
+            .Select(s => s[_random.Next(s.Length)]).ToArray());
+    }
+}

--- a/src/NexusMods.Paths.Benchmarks/Interfaces/BenchmarkInfoAttribute.cs
+++ b/src/NexusMods.Paths.Benchmarks/Interfaces/BenchmarkInfoAttribute.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace NexusMods.Paths.Benchmarks.Interfaces;
+
+public class BenchmarkInfoAttribute : Attribute
+{
+    public string? Name { get; set; }
+    public string? Description { get; set; }
+
+    public BenchmarkInfoAttribute(string? name, string? description)
+    {
+        Name = name;
+        Description = description;
+    }
+}

--- a/src/NexusMods.Paths.Benchmarks/Interfaces/IBenchmark.cs
+++ b/src/NexusMods.Paths.Benchmarks/Interfaces/IBenchmark.cs
@@ -1,0 +1,6 @@
+namespace NexusMods.Paths.Benchmarks.Interfaces;
+
+/// <summary>
+/// Common base interface for benchmarks.
+/// </summary>
+public interface IBenchmark { }

--- a/src/NexusMods.Paths.Benchmarks/NexusMods.Paths.Benchmarks.csproj
+++ b/src/NexusMods.Paths.Benchmarks/NexusMods.Paths.Benchmarks.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="BenchmarkDotNet" Version="0.13.8" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\NexusMods.Paths\NexusMods.Paths.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/NexusMods.Paths.Benchmarks/Program.cs
+++ b/src/NexusMods.Paths.Benchmarks/Program.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using BenchmarkDotNet.Running;
 using NexusMods.Paths.Benchmarks;
+using NexusMods.Paths.Benchmarks.Benchmarks;
 using NexusMods.Paths.Benchmarks.Interfaces;
 
 var benchmarks = Assembly.GetExecutingAssembly()

--- a/src/NexusMods.Paths.Benchmarks/Program.cs
+++ b/src/NexusMods.Paths.Benchmarks/Program.cs
@@ -1,0 +1,57 @@
+// See https://aka.ms/new-console-template for more information
+
+using System;
+using System.Linq;
+using System.Reflection;
+using BenchmarkDotNet.Running;
+using NexusMods.Paths.Benchmarks;
+using NexusMods.Paths.Benchmarks.Interfaces;
+
+var benchmarks = Assembly.GetExecutingAssembly()
+    .GetTypes()
+    .Where(x => x.IsAssignableTo(typeof(IBenchmark)) && x != typeof(IBenchmark))
+    .Select(x => new SelectableBenchmark(x))
+    .ToArray();
+
+Console.WriteLine("Note: Benchmarks can be ran directly by passing arguments in CLI, e.g. NexusMods.Benchmarks.dll 0 1\n");
+if (args.Length > 0)
+{
+    foreach (var arg in args)
+    {
+        if (int.TryParse(arg, out var result) && (result >= 0 && result < benchmarks.Length))
+            BenchmarkRunner.Run(benchmarks[result].Type);
+    }
+
+    return;
+}
+
+while (true)
+{
+    Console.WriteLine("Select a Benchmark");
+
+    var origColour = Console.ForegroundColor;
+
+    Console.ForegroundColor = ConsoleColor.Green;
+    for (var x = 0; x < benchmarks.Length; x++)
+        PrintOption(x, benchmarks[x]);
+
+    Console.ForegroundColor = origColour;
+    Console.WriteLine("\nEnter any invalid number to exit.");
+
+    var line = Console.ReadLine();
+    if (int.TryParse(line, out var result))
+    {
+        if (result >= 0 && result < benchmarks.Length)
+            BenchmarkRunner.Run(benchmarks[result].Type);
+        else
+            return;
+    }
+}
+
+void PrintOption(int x, SelectableBenchmark benchmark)
+{
+    Console.ForegroundColor = ConsoleColor.White;
+    Console.Write($"{x}. {benchmark.Name}: ");
+    Console.ForegroundColor = ConsoleColor.Green;
+    Console.WriteLine(benchmark.Description);
+}

--- a/src/NexusMods.Paths.Benchmarks/SelectableBenchmark.cs
+++ b/src/NexusMods.Paths.Benchmarks/SelectableBenchmark.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Reflection;
+using NexusMods.Paths.Benchmarks.Interfaces;
+
+namespace NexusMods.Paths.Benchmarks;
+
+/// <summary>
+/// A benchmark that can be ran by the user.
+/// </summary>
+public record SelectableBenchmark
+{
+    /// <summary>
+    /// Type behind the benchmark.
+    /// </summary>
+    public Type Type { get; init; }
+
+    /// <summary>
+    /// Name of the benchmark.
+    /// </summary>
+    public string Name { get; init; }
+
+    /// <summary>
+    /// Description of the benchmark.
+    /// </summary>
+    public string Description { get; init; }
+
+    public SelectableBenchmark(Type type)
+    {
+        Type = type;
+        Name = Type.Name;
+        Description = string.Empty;
+
+        var info = Type.GetCustomAttribute<BenchmarkInfoAttribute>(true);
+        if (info == null)
+            return;
+
+        Name = info.Name ?? Name;
+        Description = info.Description ?? Description;
+    }
+}

--- a/src/NexusMods.Paths/FileTree/FileTreeNode.cs
+++ b/src/NexusMods.Paths/FileTree/FileTreeNode.cs
@@ -15,11 +15,10 @@ namespace NexusMods.Paths.FileTree;
 public class FileTreeNode<TPath, TValue> : IFileTree<FileTreeNode<TPath, TValue>>
     where TPath : struct, IPath<TPath>, IEquatable<TPath>
 {
-    private readonly bool _isFile;
-
     private readonly Dictionary<RelativePath, FileTreeNode<TPath, TValue>> _children;
     private FileTreeNode<TPath, TValue>? _parent;
     private ushort _depth;
+    private readonly bool _isFile;
 
     /// <summary>
     /// Constructs a new <see cref="FileTreeNode{TPath,TValue}"/> with the given path, name, parent and value.

--- a/src/NexusMods.Paths/FileTree/IFileTree.cs
+++ b/src/NexusMods.Paths/FileTree/IFileTree.cs
@@ -69,5 +69,5 @@ public interface IFileTree<TFileTree> where TFileTree : IFileTree<TFileTree>
     /// <remarks>
     /// Returns an empty collection if this node is a file.
     /// </remarks>
-    public IEnumerable<TFileTree> GetAllDescendentFiles();
+    public List<TFileTree> GetAllDescendentFiles();
 }

--- a/src/NexusMods.Paths/NexusMods.Paths.csproj
+++ b/src/NexusMods.Paths/NexusMods.Paths.csproj
@@ -9,4 +9,8 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
         <PackageReference Include="Vogen" Version="3.0.20" />
     </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="NexusMods.Paths.Benchmarks" />
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
Associated details in the following Issues:

- https://github.com/Nexus-Mods/NexusMods.Paths/issues/22
- https://github.com/Nexus-Mods/NexusMods.Paths/issues/21

Benchmarks: 

(On 110476 files)

```
| Method                 | Mean      | Error     | StdDev    | Gen0     | Gen1    | Gen2    | Allocated |
|----------------------- |----------:|----------:|----------:|---------:|--------:|--------:|----------:|
| GetDescendants         |  3.532 ms | 0.0678 ms | 0.0635 ms |  74.2188 | 31.2500 | 31.2500 |   2.57 MB |
| OriginalGetDescendants | 16.972 ms | 0.3383 ms | 0.4154 ms | 562.5000 | 31.2500 | 31.2500 |  10.47 MB |
```

The improved `GetAllDescendentFiles` is a stripped down version of some code I wrote for Advanced Installer backend; figured I'd backport it.

Note: The benchmark code is copied 1:1 verbatim from the App repo, no review is needed there.