### PR TITLE
Added: Missing EnumerateDirectories re-export in AbsolutePath

### DIFF
--- a/src/NexusMods.Paths/AbsolutePath_IO.cs
+++ b/src/NexusMods.Paths/AbsolutePath_IO.cs
@@ -85,6 +85,10 @@ public readonly partial struct AbsolutePath
     public IEnumerable<AbsolutePath> EnumerateFiles(string pattern = "*", bool recursive = true)
         => FileSystem.EnumerateFiles(this, pattern, recursive);
 
+    /// <inheritdoc cref="IFileSystem.EnumerateDirectories"/>
+    IEnumerable<AbsolutePath> EnumerateDirectories(string pattern = "*", bool recursive = true) =>
+        FileSystem.EnumerateDirectories(this, pattern, recursive);
+
     /// <inheritdoc cref="IFileSystem.EnumerateFileEntries"/>
     public IEnumerable<IFileEntry> EnumerateFileEntries(string pattern = "*", bool recursive = true)
         => FileSystem.EnumerateFileEntries(this, pattern, recursive);


### PR DESCRIPTION
Method `EnumerateDirectories` is missing in `AbsolutePath_IO`, whereas the other methods around it from `IFileSystem` are re-exported. This PR adds the missing method.