### PR TITLE
Trait Driven Trees 2.0

### DIFF
--- a/docs/Trees/Introduction.md
+++ b/docs/Trees/Introduction.md
@@ -171,7 +171,7 @@ Available Methods:
 !!! note "Modifiers are based on [Static Abstract](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/static-virtual-interface-members) Interfaces."
 
 Modifiers are mostly used internally inside the library to provide specialized zero cost functionality without repeating code.
-For example, `GetFiles` method uses `IFilter` under the hood.
+For example, `GetFiles`, `GetDirectories` method(s) use `IFilter` under the hood.
 
 | Modifier    | Description                             |
 |-------------|-----------------------------------------|

--- a/docs/Trees/Introduction.md
+++ b/docs/Trees/Introduction.md
@@ -55,8 +55,8 @@ public struct TreeNode : IHaveBoxedChildrenWithKey<RelativePath, TreeNode>
 {
     public Dictionary<RelativePath, ChildrenWithKeyBox<RelativePath, TreeNode>> Children { get; }
 
-    // Create a Constructor. 
-    public static KeyedBox<int, TestTree> Create(Dictionary<int, KeyedBox<int, TestTree>>? children = null) 
+    // Create a Constructor.
+    public static KeyedBox<int, TestTree> Create(Dictionary<int, KeyedBox<int, TestTree>>? children = null)
         => (KeyedBox<int, TestTree>) new TestTree()
         {
             Children = children ?? new Dictionary<int, KeyedBox<int, TestTree>>()
@@ -68,16 +68,16 @@ public struct TreeNode : IHaveBoxedChildrenWithKey<RelativePath, TreeNode>
 
 !!! tip "Not Boxing the Root"
 
-    Depending on your use case, you can choose to not box the root, and store unboxed `TestTree` directly in a class.  
+    Depending on your use case, you can choose to not box the root, and store unboxed `TestTree` directly in a class.
     This saves a pointer dereference.
 
 !!! warning
 
-    Some methods (they are deliberately marked 'Obsolete') may also cause a box/heap allocation if called from unboxed item.  
+    Some methods (they are deliberately marked 'Obsolete') may also cause a box/heap allocation if called from unboxed item.
 
-If you don't box the root, you might sometimes need to specify the generic types manually on method calls (no auto inference).  
+If you don't box the root, you might sometimes need to specify the generic types manually on method calls (no auto inference).
 
-You can work around this by exporting helper methods for convenience (if desired).  
+You can work around this by exporting helper methods for convenience (if desired).
 
 ```csharp
 public struct TreeNode : IHaveBoxedChildrenWithKey<RelativePath, TreeNode>
@@ -85,7 +85,7 @@ public struct TreeNode : IHaveBoxedChildrenWithKey<RelativePath, TreeNode>
     // .. other code
 
     // [Optional] Re-export methods for convenience if you are working with non-boxed root.
-    
+
     /// <inheritdoc cref="IHaveBoxedChildrenWithKeyExtensions.CountChildren{TSelf,TKey}"/>
     public int CountChildren() => this.CountChildren<TreeNode, RelativePath>();
 
@@ -94,7 +94,7 @@ public struct TreeNode : IHaveBoxedChildrenWithKey<RelativePath, TreeNode>
 }
 ```
 
-### Adding Functionality 
+### Adding Functionality
 
 !!! info "In order to add functionality to your tree, simply implement a combination of the interfaces below."
 
@@ -126,6 +126,7 @@ Available Methods:
 | `FindSubPathsByKey`[2]       | Finds all nodes whose sub-path matches Span of keys.                          | `IHaveKey`                        |
 | `FindByKey`[2]               | Finds a given node in a tree using a Span of keys.                            | `IHaveKey`                        |
 | `FindByKeyUpward`            | Verifies the path to the node against a Span of keys (inverse FindByKey).     | `IHaveKey`, `IHaveParent`         |
+| `FindRootByKeyUpward`        | Verifies the path to the node against a Span of keys (optimized FindByKey).   | `IHaveKey`, `IHaveParent`         |
 | `FindByPath`[2]              | Finds a given node in a tree using a relative path.                           | `IHavePathSegment`                |
 | `GetChildrenRecursive`       | Retrieves all children of this node (flattened).                              |                                   |
 | `GetChildrenRecursiveUnsafe` | Retrieves all children of this node (no bound checks).                        |                                   |

--- a/docs/Trees/Introduction.md
+++ b/docs/Trees/Introduction.md
@@ -135,6 +135,8 @@ Available Methods:
 | `FindByKeyUpward`              | Verifies the path to the node against a Span of keys (inverse FindByKey).     | `IHaveKey`, `IHaveParent`         |
 | `FindRootByKeyUpward`          | Verifies the path to the node against a Span of keys (optimized FindByKey).   | `IHaveKey`, `IHaveParent`         |
 | `FindByPath`[2]                | Finds a given node in a tree using a relative path.                           | `IHavePathSegment`                |
+| `GetChildItems`                | Retrieves a certain item from all children of this node.                      | `IHaveKey`                        |
+| `GetChildItemsUnsafe`          | Retrieves a certain item from all children of this node (no bound checks).    | `IHaveKey`                        |
 | `GetChildrenRecursive`         | Retrieves all children of this node (flattened).                              |                                   |
 | `GetChildrenRecursiveUnsafe`   | Retrieves all children of this node (no bound checks).                        |                                   |
 | `GetKeys`                      | Retrieves all keys of the children of this node.                              | `IHaveKey`                        |

--- a/docs/Trees/Introduction.md
+++ b/docs/Trees/Introduction.md
@@ -158,7 +158,17 @@ Available Methods:
 
 [2] Method has variants for including and excluding itself (the root).
 
-[3] `+F` means 'has filter'. `+S` means 'has selector'
+[Modifier](#modifiers-filters--selectors) reference:
+
+| Modifier | Description                         |
+|----------|-------------------------------------|
+| +F       | Has `IFilter`                       |
+| +S       | Has `ISelector`.                    |
+
+When modifiers are separate, i.e. `+F +S`, it means there's an overload with `IFilter`, overload with `ISelector`, but not both.
+
+When modifiers are combined, i.e. `+FS`, it means all possible permutations are available, in other words, there's also
+an overload which has `IFilter` AND `ISelector` together.
 
 !!! note "All methods require one of the container interfaces such as `IHaveBoxedChildren` to be implemented, thus they are omitted from the table."
 
@@ -179,11 +189,16 @@ For example, `GetFiles`, `GetDirectories` method(s) use `IFilter` under the hood
 | `ISelector` | Allows you to select a sub-item.        |
 
 Modifiers are intended to be used in 'flattening' operations throughout the library, i.e. those that convert
-the tree into linear sequences such as Enumerators and Spans/Arrays. They are intended to minimize the need to use
-LINQ on flattened results.
+the tree into linear sequences such as Enumerators and Spans/Arrays. They are intended to minimize the need to use LINQ
+on flattened results.
 
-With modifiers you get the exact same code as if the you were to manually hand craft the specialized code (i.e. you can't
-do it any better).
+With modifiers you get the exact same code as if the you were to manually hand craft the specialized code (you can't
+do it any better). This is because essentially, your modifier implementation gets inlined directly into hand crafted
+code at compile time.
+
+***Modifiers are not a replacement for LINQ***, they're there to maximize code reuse (mostly) internally and provide
+accelerated operations in cases where normally multiple Linq operations would be needed (e.g. `Filter+Select`), to achieve
+the zero overhead promise.
 
 !!! tip "Use [LinqGen](https://github.com/cathei/LinqGen) instead of regular LINQ on returned results if further operations are needed."
 

--- a/docs/Trees/Introduction.md
+++ b/docs/Trees/Introduction.md
@@ -109,42 +109,48 @@ public struct TreeNode : IHaveBoxedChildrenWithKey<RelativePath, TreeNode>
 
 Available Methods:
 
-| Method                        | Description                                                                   | Required Traits                   |
-|-------------------------------|-------------------------------------------------------------------------------|-----------------------------------|
-| `CountChildren`               | Counts the total number of child nodes under this node.                       |                                   |
-| `CountDirectories`            | Counts directories under this node (directory).                               | `IHaveAFileOrDirectory`           |
-| `CountFiles`                  | Counts files under this node (directory).                                     | `IHaveAFileOrDirectory`           |
-| `CountLeaves`                 | Returns number of leaf nodes in this tree.                                    |                                   |
-| `EnumerateChildrenBfs`        | Enumerates children of this node Breadth First.                               |                                   |
-| `EnumerateChildrenDfs`        | Enumerates children of this node using Depth First.                           |                                   |
-| `EnumerateKeysBfs`            | Enumerates child keys of this node Breadth First.                             | `IHaveKey`                        |
-| `EnumerateKeysDfs`            | Enumerates child keys of this node using Depth First.                         | `IHaveKey`                        |
-| `EnumerateSiblings`[1]        | Enumerates (`IEnumerator`) over siblings of this node.                        | `IHaveParent`                     |
-| `EnumerateValuesBfs`          | Enumerates child values of this node Breadth First.                           | `IHaveValue`                      |
-| `EnumerateValuesDfs`          | Enumerates child values of this node using Depth First.                       | `IHaveValue`                      |
-| `FindSubPathRootsByKeyUpward` | Optimized variant of `FindSubPathsByKey` (returns roots).                     | `IHaveKey`, `IHaveParent`         |
-| `FindSubPathsByKeyUpward`     | Optimized variant of `FindSubPathsByKey` (returns leaves).                    | `IHaveKey`, `IHaveParent`         |
-| `FindSubPathsByKey`[2]        | Finds all nodes whose sub-path matches Span of keys.                          | `IHaveKey`                        |
-| `FindByKey`[2]                | Finds a given node in a tree using a Span of keys.                            | `IHaveKey`                        |
-| `FindByKeyUpward`             | Verifies the path to the node against a Span of keys (inverse FindByKey).     | `IHaveKey`, `IHaveParent`         |
-| `FindRootByKeyUpward`         | Verifies the path to the node against a Span of keys (optimized FindByKey).   | `IHaveKey`, `IHaveParent`         |
-| `FindByPath`[2]               | Finds a given node in a tree using a relative path.                           | `IHavePathSegment`                |
-| `GetChildrenRecursive`        | Retrieves all children of this node (flattened).                              |                                   |
-| `GetChildrenRecursiveUnsafe`  | Retrieves all children of this node (no bound checks).                        |                                   |
-| `GetKeys`                     | Retrieves all keys of the children of this node.                              | `IHaveKey`                        |
-| `GetKeysUnsafe`               | Retrieves all keys of the children of this node (no bound checks).            | `IHaveKey`                        |
-| `GetKeyValues`                | Retrieves all key-value pairs of the children of this node.                   | `IHaveKey`, `IHaveValue`          |
-| `GetKeyValuesUnsafe`          | Retrieves all key-value pairs of the children of this node (no bound checks). | `IHaveKey`, `IHaveValue`          |
-| `GetLeaves`                   | Retrieves all leaves of this tree.                                            |                                   |
-| `GetLeavesUnsafe`             | Retrieves all leaves of this tree (no bound checks).                          |                                   |
-| `GetSiblingCount`             | Returns the number of siblings this node has.                                 | `IHaveParent`                     |
-| `GetSiblings`[1]              | Returns all siblings of this node.                                            | `IHaveParent`                     |
-| `GetSiblingsUnsafe`[1]        | Returns all siblings of this node (no bound checks).                          | `IHaveParent`                     |
-| `GetValues`                   | Retrieves all values of the children of this node.                            | `IHaveValue`                      |
-| `GetValuesUnsafe`             | Retrieves all values of the children of this node (no bound checks).          | `IHaveValue`                      |
-| `IsLeaf`                      | Returns true if the node has no children.                                     |                                   |
-| `ReconstructPath`             | Reconstructs full path by walking to tree root.                               | `IHaveParent`, `IHavePathSegment` |
-| `ToDictionary`                | Populates a dictionary from the children of the tree node.                    | `IHaveKey`, `IHaveValue`          |
+| Method                         | Description                                                                   | Required Traits                   |
+|--------------------------------|-------------------------------------------------------------------------------|-----------------------------------|
+| `CountChildren`                | Counts the total number of child nodes under this node.                       |                                   |
+| `CountDirectories`             | Counts directories under this node (directory).                               | `IHaveAFileOrDirectory`           |
+| `CountFiles`                   | Counts files under this node (directory).                                     | `IHaveAFileOrDirectory`           |
+| `CountLeaves`                  | Returns number of leaf nodes in this tree.                                    |                                   |
+| `EnumerateChildrenBfs`         | Enumerates children of this node Breadth First.                               |                                   |
+| `EnumerateChildrenDfs`         | Enumerates children of this node using Depth First.                           |                                   |
+| `EnumerateChildrenFilteredBfs` | Enumerates children of this node with zero-cost filter (Breadth First).       |                                   |
+| `EnumerateChildrenFilteredDfs` | Enumerates children of this node with zero-cost filter (Depth First).         |                                   |
+| `EnumerateDirectoriesBfs`      | Enumerates all children that are directories (Breadth First).                 | `IHaveAFileOrDirectory`           |
+| `EnumerateDirectoriesDfs`      | Enumerates all children that are directories (Depth First).                   | `IHaveAFileOrDirectory`           |
+| `EnumerateFilesBfs`            | Enumerates all children that are files (Breadth First).                       | `IHaveAFileOrDirectory`           |
+| `EnumerateFilesDfs`            | Enumerates all children that are files (Depth First).                         | `IHaveAFileOrDirectory`           |
+| `EnumerateKeysBfs`             | Enumerates child keys of this node Breadth First.                             | `IHaveKey`                        |
+| `EnumerateKeysDfs`             | Enumerates child keys of this node using Depth First.                         | `IHaveKey`                        |
+| `EnumerateSiblings`[1]         | Enumerates (`IEnumerator`) over siblings of this node.                        | `IHaveParent`                     |
+| `EnumerateValuesBfs`           | Enumerates child values of this node Breadth First.                           | `IHaveValue`                      |
+| `EnumerateValuesDfs`           | Enumerates child values of this node using Depth First.                       | `IHaveValue`                      |
+| `FindSubPathRootsByKeyUpward`  | Optimized variant of `FindSubPathsByKey` (returns roots).                     | `IHaveKey`, `IHaveParent`         |
+| `FindSubPathsByKeyUpward`      | Optimized variant of `FindSubPathsByKey` (returns leaves).                    | `IHaveKey`, `IHaveParent`         |
+| `FindSubPathsByKey`[2]         | Finds all nodes whose sub-path matches Span of keys.                          | `IHaveKey`                        |
+| `FindByKey`[2]                 | Finds a given node in a tree using a Span of keys.                            | `IHaveKey`                        |
+| `FindByKeyUpward`              | Verifies the path to the node against a Span of keys (inverse FindByKey).     | `IHaveKey`, `IHaveParent`         |
+| `FindRootByKeyUpward`          | Verifies the path to the node against a Span of keys (optimized FindByKey).   | `IHaveKey`, `IHaveParent`         |
+| `FindByPath`[2]                | Finds a given node in a tree using a relative path.                           | `IHavePathSegment`                |
+| `GetChildrenRecursive`         | Retrieves all children of this node (flattened).                              |                                   |
+| `GetChildrenRecursiveUnsafe`   | Retrieves all children of this node (no bound checks).                        |                                   |
+| `GetKeys`                      | Retrieves all keys of the children of this node.                              | `IHaveKey`                        |
+| `GetKeysUnsafe`                | Retrieves all keys of the children of this node (no bound checks).            | `IHaveKey`                        |
+| `GetKeyValues`                 | Retrieves all key-value pairs of the children of this node.                   | `IHaveKey`, `IHaveValue`          |
+| `GetKeyValuesUnsafe`           | Retrieves all key-value pairs of the children of this node (no bound checks). | `IHaveKey`, `IHaveValue`          |
+| `GetLeaves`                    | Retrieves all leaves of this tree.                                            |                                   |
+| `GetLeavesUnsafe`              | Retrieves all leaves of this tree (no bound checks).                          |                                   |
+| `GetSiblingCount`              | Returns the number of siblings this node has.                                 | `IHaveParent`                     |
+| `GetSiblings`[1]               | Returns all siblings of this node.                                            | `IHaveParent`                     |
+| `GetSiblingsUnsafe`[1]         | Returns all siblings of this node (no bound checks).                          | `IHaveParent`                     |
+| `GetValues`                    | Retrieves all values of the children of this node.                            | `IHaveValue`                      |
+| `GetValuesUnsafe`              | Retrieves all values of the children of this node (no bound checks).          | `IHaveValue`                      |
+| `IsLeaf`                       | Returns true if the node has no children.                                     |                                   |
+| `ReconstructPath`              | Reconstructs full path by walking to tree root.                               | `IHaveParent`, `IHavePathSegment` |
+| `ToDictionary`                 | Populates a dictionary from the children of the tree node.                    | `IHaveKey`, `IHaveValue`          |
 
 [1] Siblings are determined on Value equality *when called from internal boxed struct*. This means, when called from struct, if all fields are the same on two nodes, they may be (incorrectly) assumed as same node.
 

--- a/docs/Trees/Introduction.md
+++ b/docs/Trees/Introduction.md
@@ -115,8 +115,8 @@ Available Methods:
 | `CountDirectories`              | Counts directories under this node (directory).                               | `IHaveAFileOrDirectory`           |
 | `CountFiles`                    | Counts files under this node (directory).                                     | `IHaveAFileOrDirectory`           |
 | `CountLeaves`                   | Returns number of leaf nodes in this tree.                                    |                                   |
-| `EnumerateChildrenBfs`+F        | Enumerates children of this node Breadth First.                               |                                   |
-| `EnumerateChildrenDfs`+F        | Enumerates children of this node using Depth First.                           |                                   |
+| `EnumerateChildrenBfs`+FS       | Enumerates children of this node Breadth First.                               |                                   |
+| `EnumerateChildrenDfs`+FS       | Enumerates children of this node using Depth First.                           |                                   |
 | `EnumerateDirectoriesBfs`       | Enumerates all children that are directories (Breadth First).                 | `IHaveAFileOrDirectory`           |
 | `EnumerateDirectoriesDfs`       | Enumerates all children that are directories (Depth First).                   | `IHaveAFileOrDirectory`           |
 | `EnumerateFilesBfs`             | Enumerates all children that are files (Breadth First).                       | `IHaveAFileOrDirectory`           |
@@ -160,10 +160,10 @@ Available Methods:
 
 [Modifier](#modifiers-filters--selectors) reference:
 
-| Modifier | Description                         |
-|----------|-------------------------------------|
-| +F       | Has `IFilter`                       |
-| +S       | Has `ISelector`.                    |
+| Modifier | Description     |
+|----------|-----------------|
+| +F       | Has `IFilter`   |
+| +S       | Has `ISelector` |
 
 When modifiers are separate, i.e. `+F +S`, it means there's an overload with `IFilter`, overload with `ISelector`, but not both.
 

--- a/docs/Trees/Introduction.md
+++ b/docs/Trees/Introduction.md
@@ -109,58 +109,109 @@ public struct TreeNode : IHaveBoxedChildrenWithKey<RelativePath, TreeNode>
 
 Available Methods:
 
-| Method                         | Description                                                                   | Required Traits                   |
-|--------------------------------|-------------------------------------------------------------------------------|-----------------------------------|
-| `CountChildren`                | Counts the total number of child nodes under this node (w/ optional filter).  |                                   |
-| `CountDirectories`             | Counts directories under this node (directory).                               | `IHaveAFileOrDirectory`           |
-| `CountFiles`                   | Counts files under this node (directory).                                     | `IHaveAFileOrDirectory`           |
-| `CountLeaves`                  | Returns number of leaf nodes in this tree.                                    |                                   |
-| `EnumerateChildrenBfs`         | Enumerates children of this node Breadth First.                               |                                   |
-| `EnumerateChildrenDfs`         | Enumerates children of this node using Depth First.                           |                                   |
-| `EnumerateChildrenFilteredBfs` | Enumerates children of this node with zero-cost filter (Breadth First).       |                                   |
-| `EnumerateChildrenFilteredDfs` | Enumerates children of this node with zero-cost filter (Depth First).         |                                   |
-| `EnumerateDirectoriesBfs`      | Enumerates all children that are directories (Breadth First).                 | `IHaveAFileOrDirectory`           |
-| `EnumerateDirectoriesDfs`      | Enumerates all children that are directories (Depth First).                   | `IHaveAFileOrDirectory`           |
-| `EnumerateFilesBfs`            | Enumerates all children that are files (Breadth First).                       | `IHaveAFileOrDirectory`           |
-| `EnumerateFilesDfs`            | Enumerates all children that are files (Depth First).                         | `IHaveAFileOrDirectory`           |
-| `EnumerateKeysBfs`             | Enumerates child keys of this node Breadth First.                             | `IHaveKey`                        |
-| `EnumerateKeysDfs`             | Enumerates child keys of this node using Depth First.                         | `IHaveKey`                        |
-| `EnumerateSiblings`[1]         | Enumerates (`IEnumerator`) over siblings of this node.                        | `IHaveParent`                     |
-| `EnumerateValuesBfs`           | Enumerates child values of this node Breadth First.                           | `IHaveValue`                      |
-| `EnumerateValuesDfs`           | Enumerates child values of this node using Depth First.                       | `IHaveValue`                      |
-| `FindSubPathRootsByKeyUpward`  | Optimized variant of `FindSubPathsByKey` (returns roots).                     | `IHaveKey`, `IHaveParent`         |
-| `FindSubPathsByKeyUpward`      | Optimized variant of `FindSubPathsByKey` (returns leaves).                    | `IHaveKey`, `IHaveParent`         |
-| `FindSubPathsByKey`[2]         | Finds all nodes whose sub-path matches Span of keys.                          | `IHaveKey`                        |
-| `FindByKey`[2]                 | Finds a given node in a tree using a Span of keys.                            | `IHaveKey`                        |
-| `FindByKeyUpward`              | Verifies the path to the node against a Span of keys (inverse FindByKey).     | `IHaveKey`, `IHaveParent`         |
-| `FindRootByKeyUpward`          | Verifies the path to the node against a Span of keys (optimized FindByKey).   | `IHaveKey`, `IHaveParent`         |
-| `FindByPath`[2]                | Finds a given node in a tree using a relative path.                           | `IHavePathSegment`                |
-| `GetChildItems`                | Retrieves a certain item from all children of this node.                      |                                   |
-| `GetChildItemsUnsafe`          | Retrieves a certain item from all children of this node (no bound checks).    |                                   |
-| `GetChildrenRecursive`         | Retrieves all children of this node (flattened).                              |                                   |
-| `GetChildrenRecursiveUnsafe`   | Retrieves all children of this node (no bound checks).                        |                                   |
-| `GetKeys`                      | Retrieves all keys of the children of this node.                              | `IHaveKey`                        |
-| `GetKeysUnsafe`                | Retrieves all keys of the children of this node (no bound checks).            | `IHaveKey`                        |
-| `GetKeyValues`                 | Retrieves all key-value pairs of the children of this node.                   | `IHaveKey`, `IHaveValue`          |
-| `GetKeyValuesUnsafe`           | Retrieves all key-value pairs of the children of this node (no bound checks). | `IHaveKey`, `IHaveValue`          |
-| `GetLeaves`                    | Retrieves all leaves of this tree.                                            |                                   |
-| `GetLeavesUnsafe`              | Retrieves all leaves of this tree (no bound checks).                          |                                   |
-| `GetSiblingCount`              | Returns the number of siblings this node has.                                 | `IHaveParent`                     |
-| `GetSiblings`[1]               | Returns all siblings of this node.                                            | `IHaveParent`                     |
-| `GetSiblingsUnsafe`[1]         | Returns all siblings of this node (no bound checks).                          | `IHaveParent`                     |
-| `GetValues`                    | Retrieves all values of the children of this node.                            | `IHaveValue`                      |
-| `GetValuesUnsafe`              | Retrieves all values of the children of this node (no bound checks).          | `IHaveValue`                      |
-| `IsLeaf`                       | Returns true if the node has no children.                                     |                                   |
-| `ReconstructPath`              | Reconstructs full path by walking to tree root.                               | `IHaveParent`, `IHavePathSegment` |
-| `ToDictionary`                 | Populates a dictionary from the children of the tree node.                    | `IHaveKey`, `IHaveValue`          |
+| Method                          | Description                                                                   | Required Traits                   |
+|---------------------------------|-------------------------------------------------------------------------------|-----------------------------------|
+| `CountChildren`+F               | Counts the total number of child nodes under this node.                       |                                   |
+| `CountDirectories`              | Counts directories under this node (directory).                               | `IHaveAFileOrDirectory`           |
+| `CountFiles`                    | Counts files under this node (directory).                                     | `IHaveAFileOrDirectory`           |
+| `CountLeaves`                   | Returns number of leaf nodes in this tree.                                    |                                   |
+| `EnumerateChildrenBfs`+F        | Enumerates children of this node Breadth First.                               |                                   |
+| `EnumerateChildrenDfs`+F        | Enumerates children of this node using Depth First.                           |                                   |
+| `EnumerateDirectoriesBfs`       | Enumerates all children that are directories (Breadth First).                 | `IHaveAFileOrDirectory`           |
+| `EnumerateDirectoriesDfs`       | Enumerates all children that are directories (Depth First).                   | `IHaveAFileOrDirectory`           |
+| `EnumerateFilesBfs`             | Enumerates all children that are files (Breadth First).                       | `IHaveAFileOrDirectory`           |
+| `EnumerateFilesDfs`             | Enumerates all children that are files (Depth First).                         | `IHaveAFileOrDirectory`           |
+| `EnumerateKeysBfs`              | Enumerates child keys of this node Breadth First.                             | `IHaveKey`                        |
+| `EnumerateKeysDfs`              | Enumerates child keys of this node using Depth First.                         | `IHaveKey`                        |
+| `EnumerateSiblings`[1]          | Enumerates (`IEnumerator`) over siblings of this node.                        | `IHaveParent`                     |
+| `EnumerateValuesBfs`            | Enumerates child values of this node Breadth First.                           | `IHaveValue`                      |
+| `EnumerateValuesDfs`            | Enumerates child values of this node using Depth First.                       | `IHaveValue`                      |
+| `FindSubPathRootsByKeyUpward`   | Optimized variant of `FindSubPathsByKey` (returns roots).                     | `IHaveKey`, `IHaveParent`         |
+| `FindSubPathsByKeyUpward`       | Optimized variant of `FindSubPathsByKey` (returns leaves).                    | `IHaveKey`, `IHaveParent`         |
+| `FindSubPathsByKey`[2]          | Finds all nodes whose sub-path matches Span of keys.                          | `IHaveKey`                        |
+| `FindByKey`[2]                  | Finds a given node in a tree using a Span of keys.                            | `IHaveKey`                        |
+| `FindByKeyUpward`               | Verifies the path to the node against a Span of keys (inverse FindByKey).     | `IHaveKey`, `IHaveParent`         |
+| `FindRootByKeyUpward`           | Verifies the path to the node against a Span of keys (optimized FindByKey).   | `IHaveKey`, `IHaveParent`         |
+| `FindByPath`[2]                 | Finds a given node in a tree using a relative path.                           | `IHavePathSegment`                |
+| `GetChildrenRecursive`+FS       | Retrieves all children of this node (flattened).                              |                                   |
+| `GetChildrenRecursiveUnsafe`+FS | Retrieves all children of this node (no bound checks).                        |                                   |
+| `GetDirectories`                | Retrieves all children of this node that are directories (flattened).         | `IHaveAFileOrDirectory`           |
+| `GetDirectoriesUnsafe`          | Retrieves all children of this node that are directories (no bound checks).   | `IHaveAFileOrDirectory`           |
+| `GetFiles`                      | Retrieves all children of this node that are files (flattened).               | `IHaveAFileOrDirectory`           |
+| `GetFilesUnsafe`                | Retrieves all children of this node that are files (no bound checks).         | `IHaveAFileOrDirectory`           |
+| `GetKeys`                       | Retrieves all keys of the children of this node.                              | `IHaveKey`                        |
+| `GetKeysUnsafe`                 | Retrieves all keys of the children of this node (no bound checks).            | `IHaveKey`                        |
+| `GetKeyValues`                  | Retrieves all key-value pairs of the children of this node.                   | `IHaveKey`, `IHaveValue`          |
+| `GetKeyValuesUnsafe`            | Retrieves all key-value pairs of the children of this node (no bound checks). | `IHaveKey`, `IHaveValue`          |
+| `GetLeaves`                     | Retrieves all leaves of this tree.                                            |                                   |
+| `GetLeavesUnsafe`               | Retrieves all leaves of this tree (no bound checks).                          |                                   |
+| `GetSiblingCount`               | Returns the number of siblings this node has.                                 | `IHaveParent`                     |
+| `GetSiblings`[1]                | Returns all siblings of this node.                                            | `IHaveParent`                     |
+| `GetSiblingsUnsafe`[1]          | Returns all siblings of this node (no bound checks).                          | `IHaveParent`                     |
+| `GetValues`                     | Retrieves all values of the children of this node.                            | `IHaveValue`                      |
+| `GetValuesUnsafe`               | Retrieves all values of the children of this node (no bound checks).          | `IHaveValue`                      |
+| `IsLeaf`                        | Returns true if the node has no children.                                     |                                   |
+| `ReconstructPath`               | Reconstructs full path by walking to tree root.                               | `IHaveParent`, `IHavePathSegment` |
+| `ToDictionary`                  | Populates a dictionary from the children of the tree node.                    | `IHaveKey`, `IHaveValue`          |
 
 [1] Siblings are determined on Value equality *when called from internal boxed struct*. This means, when called from struct, if all fields are the same on two nodes, they may be (incorrectly) assumed as same node.
 
 [2] Method has variants for including and excluding itself (the root).
 
+[3] `+F` means 'has filter'. `+S` means 'has selector'
+
 !!! note "All methods require one of the container interfaces such as `IHaveBoxedChildren` to be implemented, thus they are omitted from the table."
 
 !!! note "Unless specified, the functions ignore the current node. e.g. `GetValues`, `CountLeaves` etc. will return only children."
+
+## Modifiers (Filters & Selectors)
+
+!!! info "Some operations have modifiers that can be used to augment their behaviour in a zero cost manner."
+
+!!! note "Modifiers are based on [Static Abstract](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/static-virtual-interface-members) Interfaces."
+
+Modifiers are mostly used internally inside the library to provide specialized zero cost functionality without repeating code.
+For example, `GetFiles` method uses `IFilter` under the hood.
+
+| Modifier    | Description                             |
+|-------------|-----------------------------------------|
+| `IFilter`   | Filters which items should be returned. |
+| `ISelector` | Allows you to select a sub-item.        |
+
+Modifiers are intended to be used in 'flattening' operations throughout the library, i.e. those that convert
+the tree into linear sequences such as Enumerators and Spans/Arrays. They are intended to minimize the need to use
+LINQ on flattened results.
+
+With modifiers you get the exact same code as if the you were to manually hand craft the specialized code (i.e. you can't
+do it any better).
+
+!!! tip "Use [LinqGen](https://github.com/cathei/LinqGen) instead of regular LINQ on returned results if further operations are needed."
+
+### Using Filters
+
+!!! info "Specifies which nodes should be included in an operation. i.e. `Where` in LINQ"
+
+```csharp
+internal struct FileFilter<TSelf> : IFilter<TSelf> where TSelf : struct, IHaveAFileOrDirectory
+{
+    public static bool Match(TSelf item) => item.IsFile;
+}
+```
+
+And when method has a generic with `where IFilter<T>` constraint, pass `FileFilter<TSelf>`.
+
+### Using Selectors
+
+!!! info "A selector transforms the selected notes into a different form. i.e. `Select` in LINQ"
+
+```csharp
+internal struct ValueSelector<TSelf, TValue> : ISelector<TSelf, TValue> where TSelf : struct, IHaveValue<TValue>
+{
+    public static TValue Select(TSelf item) => item.Value;
+}
+```
+
+And when method has a generic with `where ISelector<TSelf, TValue>` constraint, pass `ValueSelector<TSelf, TValue>`.
 
 # Benchmarks
 

--- a/docs/Trees/Introduction.md
+++ b/docs/Trees/Introduction.md
@@ -111,7 +111,7 @@ Available Methods:
 
 | Method                         | Description                                                                   | Required Traits                   |
 |--------------------------------|-------------------------------------------------------------------------------|-----------------------------------|
-| `CountChildren`                | Counts the total number of child nodes under this node.                       |                                   |
+| `CountChildren`                | Counts the total number of child nodes under this node (w/ optional filter).  |                                   |
 | `CountDirectories`             | Counts directories under this node (directory).                               | `IHaveAFileOrDirectory`           |
 | `CountFiles`                   | Counts files under this node (directory).                                     | `IHaveAFileOrDirectory`           |
 | `CountLeaves`                  | Returns number of leaf nodes in this tree.                                    |                                   |

--- a/docs/Trees/Introduction.md
+++ b/docs/Trees/Introduction.md
@@ -135,8 +135,8 @@ Available Methods:
 | `FindByKeyUpward`              | Verifies the path to the node against a Span of keys (inverse FindByKey).     | `IHaveKey`, `IHaveParent`         |
 | `FindRootByKeyUpward`          | Verifies the path to the node against a Span of keys (optimized FindByKey).   | `IHaveKey`, `IHaveParent`         |
 | `FindByPath`[2]                | Finds a given node in a tree using a relative path.                           | `IHavePathSegment`                |
-| `GetChildItems`                | Retrieves a certain item from all children of this node.                      | `IHaveKey`                        |
-| `GetChildItemsUnsafe`          | Retrieves a certain item from all children of this node (no bound checks).    | `IHaveKey`                        |
+| `GetChildItems`                | Retrieves a certain item from all children of this node.                      |                                   |
+| `GetChildItemsUnsafe`          | Retrieves a certain item from all children of this node (no bound checks).    |                                   |
 | `GetChildrenRecursive`         | Retrieves all children of this node (flattened).                              |                                   |
 | `GetChildrenRecursiveUnsafe`   | Retrieves all children of this node (no bound checks).                        |                                   |
 | `GetKeys`                      | Retrieves all keys of the children of this node.                              | `IHaveKey`                        |

--- a/docs/Trees/Introduction.md
+++ b/docs/Trees/Introduction.md
@@ -109,41 +109,42 @@ public struct TreeNode : IHaveBoxedChildrenWithKey<RelativePath, TreeNode>
 
 Available Methods:
 
-| Method                       | Description                                                                   | Required Traits                   |
-|------------------------------|-------------------------------------------------------------------------------|-----------------------------------|
-| `CountChildren`              | Counts the total number of child nodes under this node.                       |                                   |
-| `CountDirectories`           | Counts directories under this node (directory).                               | `IHaveAFileOrDirectory`           |
-| `CountFiles`                 | Counts files under this node (directory).                                     | `IHaveAFileOrDirectory`           |
-| `CountLeaves`                | Returns number of leaf nodes in this tree.                                    |                                   |
-| `EnumerateChildrenBfs`       | Enumerates children of this node Breadth First.                               |                                   |
-| `EnumerateChildrenDfs`       | Enumerates children of this node using Depth First.                           |                                   |
-| `EnumerateKeysBfs`           | Enumerates child keys of this node Breadth First.                             | `IHaveKey`                        |
-| `EnumerateKeysDfs`           | Enumerates child keys of this node using Depth First.                         | `IHaveKey`                        |
-| `EnumerateSiblings`[1]       | Enumerates (`IEnumerator`) over siblings of this node.                        | `IHaveParent`                     |
-| `EnumerateValuesBfs`         | Enumerates child values of this node Breadth First.                           | `IHaveValue`                      |
-| `EnumerateValuesDfs`         | Enumerates child values of this node using Depth First.                       | `IHaveValue`                      |
-| `FindSubPathsByKeyUpward`    | Finds all nodes whose sub-path matches Span of keys (optimized version).      | `IHaveKey`, `IHaveParent`         |
-| `FindSubPathsByKey`[2]       | Finds all nodes whose sub-path matches Span of keys.                          | `IHaveKey`                        |
-| `FindByKey`[2]               | Finds a given node in a tree using a Span of keys.                            | `IHaveKey`                        |
-| `FindByKeyUpward`            | Verifies the path to the node against a Span of keys (inverse FindByKey).     | `IHaveKey`, `IHaveParent`         |
-| `FindRootByKeyUpward`        | Verifies the path to the node against a Span of keys (optimized FindByKey).   | `IHaveKey`, `IHaveParent`         |
-| `FindByPath`[2]              | Finds a given node in a tree using a relative path.                           | `IHavePathSegment`                |
-| `GetChildrenRecursive`       | Retrieves all children of this node (flattened).                              |                                   |
-| `GetChildrenRecursiveUnsafe` | Retrieves all children of this node (no bound checks).                        |                                   |
-| `GetKeys`                    | Retrieves all keys of the children of this node.                              | `IHaveKey`                        |
-| `GetKeysUnsafe`              | Retrieves all keys of the children of this node (no bound checks).            | `IHaveKey`                        |
-| `GetKeyValues`               | Retrieves all key-value pairs of the children of this node.                   | `IHaveKey`, `IHaveValue`          |
-| `GetKeyValuesUnsafe`         | Retrieves all key-value pairs of the children of this node (no bound checks). | `IHaveKey`, `IHaveValue`          |
-| `GetLeaves`                  | Retrieves all leaves of this tree.                                            |                                   |
-| `GetLeavesUnsafe`            | Retrieves all leaves of this tree (no bound checks).                          |                                   |
-| `GetSiblingCount`            | Returns the number of siblings this node has.                                 | `IHaveParent`                     |
-| `GetSiblings`[1]             | Returns all siblings of this node.                                            | `IHaveParent`                     |
-| `GetSiblingsUnsafe`[1]       | Returns all siblings of this node (no bound checks).                          | `IHaveParent`                     |
-| `GetValues`                  | Retrieves all values of the children of this node.                            | `IHaveValue`                      |
-| `GetValuesUnsafe`            | Retrieves all values of the children of this node (no bound checks).          | `IHaveValue`                      |
-| `IsLeaf`                     | Returns true if the node has no children.                                     |                                   |
-| `ReconstructPath`            | Reconstructs full path by walking to tree root.                               | `IHaveParent`, `IHavePathSegment` |
-| `ToDictionary`               | Populates a dictionary from the children of the tree node.                    | `IHaveKey`, `IHaveValue`          |
+| Method                        | Description                                                                   | Required Traits                   |
+|-------------------------------|-------------------------------------------------------------------------------|-----------------------------------|
+| `CountChildren`               | Counts the total number of child nodes under this node.                       |                                   |
+| `CountDirectories`            | Counts directories under this node (directory).                               | `IHaveAFileOrDirectory`           |
+| `CountFiles`                  | Counts files under this node (directory).                                     | `IHaveAFileOrDirectory`           |
+| `CountLeaves`                 | Returns number of leaf nodes in this tree.                                    |                                   |
+| `EnumerateChildrenBfs`        | Enumerates children of this node Breadth First.                               |                                   |
+| `EnumerateChildrenDfs`        | Enumerates children of this node using Depth First.                           |                                   |
+| `EnumerateKeysBfs`            | Enumerates child keys of this node Breadth First.                             | `IHaveKey`                        |
+| `EnumerateKeysDfs`            | Enumerates child keys of this node using Depth First.                         | `IHaveKey`                        |
+| `EnumerateSiblings`[1]        | Enumerates (`IEnumerator`) over siblings of this node.                        | `IHaveParent`                     |
+| `EnumerateValuesBfs`          | Enumerates child values of this node Breadth First.                           | `IHaveValue`                      |
+| `EnumerateValuesDfs`          | Enumerates child values of this node using Depth First.                       | `IHaveValue`                      |
+| `FindSubPathRootsByKeyUpward` | Optimized variant of `FindSubPathsByKey` (returns roots).                     | `IHaveKey`, `IHaveParent`         |
+| `FindSubPathsByKeyUpward`     | Optimized variant of `FindSubPathsByKey` (returns leaves).                    | `IHaveKey`, `IHaveParent`         |
+| `FindSubPathsByKey`[2]        | Finds all nodes whose sub-path matches Span of keys.                          | `IHaveKey`                        |
+| `FindByKey`[2]                | Finds a given node in a tree using a Span of keys.                            | `IHaveKey`                        |
+| `FindByKeyUpward`             | Verifies the path to the node against a Span of keys (inverse FindByKey).     | `IHaveKey`, `IHaveParent`         |
+| `FindRootByKeyUpward`         | Verifies the path to the node against a Span of keys (optimized FindByKey).   | `IHaveKey`, `IHaveParent`         |
+| `FindByPath`[2]               | Finds a given node in a tree using a relative path.                           | `IHavePathSegment`                |
+| `GetChildrenRecursive`        | Retrieves all children of this node (flattened).                              |                                   |
+| `GetChildrenRecursiveUnsafe`  | Retrieves all children of this node (no bound checks).                        |                                   |
+| `GetKeys`                     | Retrieves all keys of the children of this node.                              | `IHaveKey`                        |
+| `GetKeysUnsafe`               | Retrieves all keys of the children of this node (no bound checks).            | `IHaveKey`                        |
+| `GetKeyValues`                | Retrieves all key-value pairs of the children of this node.                   | `IHaveKey`, `IHaveValue`          |
+| `GetKeyValuesUnsafe`          | Retrieves all key-value pairs of the children of this node (no bound checks). | `IHaveKey`, `IHaveValue`          |
+| `GetLeaves`                   | Retrieves all leaves of this tree.                                            |                                   |
+| `GetLeavesUnsafe`             | Retrieves all leaves of this tree (no bound checks).                          |                                   |
+| `GetSiblingCount`             | Returns the number of siblings this node has.                                 | `IHaveParent`                     |
+| `GetSiblings`[1]              | Returns all siblings of this node.                                            | `IHaveParent`                     |
+| `GetSiblingsUnsafe`[1]        | Returns all siblings of this node (no bound checks).                          | `IHaveParent`                     |
+| `GetValues`                   | Retrieves all values of the children of this node.                            | `IHaveValue`                      |
+| `GetValuesUnsafe`             | Retrieves all values of the children of this node (no bound checks).          | `IHaveValue`                      |
+| `IsLeaf`                      | Returns true if the node has no children.                                     |                                   |
+| `ReconstructPath`             | Reconstructs full path by walking to tree root.                               | `IHaveParent`, `IHavePathSegment` |
+| `ToDictionary`                | Populates a dictionary from the children of the tree node.                    | `IHaveKey`, `IHaveValue`          |
 
 [1] Siblings are determined on Value equality *when called from internal boxed struct*. This means, when called from struct, if all fields are the same on two nodes, they may be (incorrectly) assumed as same node.
 

--- a/src/NexusMods.Paths/Trees/Box.cs
+++ b/src/NexusMods.Paths/Trees/Box.cs
@@ -41,7 +41,7 @@ public class Box<TSelf> : IEquatable<Box<TSelf>> where TSelf : struct
     {
         if (ReferenceEquals(null, obj)) return false;
         if (ReferenceEquals(this, obj)) return true;
-        if (obj.GetType() != this.GetType()) return false;
+        if (obj.GetType() != GetType()) return false;
         return Equals((Box<TSelf>)obj);
     }
 

--- a/src/NexusMods.Paths/Trees/KeyedBox.cs
+++ b/src/NexusMods.Paths/Trees/KeyedBox.cs
@@ -34,7 +34,7 @@ public class KeyedBox<TKey, TSelf> : Box<TSelf>, IEquatable<KeyedBox<TKey, TSelf
     {
         if (ReferenceEquals(null, obj)) return false;
         if (ReferenceEquals(this, obj)) return true;
-        if (obj.GetType() != this.GetType()) return false;
+        if (obj.GetType() != GetType()) return false;
         return Equals((KeyedBox<TKey, TSelf>)obj);
     }
 

--- a/src/NexusMods.Paths/Trees/KeyedBox.cs
+++ b/src/NexusMods.Paths/Trees/KeyedBox.cs
@@ -14,6 +14,9 @@ namespace NexusMods.Paths.Trees;
 public class KeyedBox<TKey, TSelf> : Box<TSelf>, IEquatable<KeyedBox<TKey, TSelf>> where TSelf : struct
     where TKey : notnull
 {
+    // !! DO NOT ADD ANY FIELDS HERE !!
+    // BOX AND KEYEDBOX MUST HAVE SAME LAYOUT, DUE TO THIS BEING UNSAFE UPCASTED
+
     /// <summary />
     public static implicit operator TSelf(KeyedBox<TKey, TSelf> box) => box.Item;
 

--- a/src/NexusMods.Paths/Trees/Traits/IHaveAFileOrDirectory.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveAFileOrDirectory.cs
@@ -280,15 +280,45 @@ public static class IHaveAFileOrDirectoryExtensionsForIHaveObservableChildren
 /// <summary>
 ///     Trait methods for <see cref="IHaveAFileOrDirectory"/>.
 /// </summary>
+[ExcludeFromCodeCoverage] // Wrapper
 // ReSharper disable once InconsistentNaming
 public static class IHaveAFileOrDirectoryExtensions
 {
     /// <summary>
-    ///      Returns true if this item represents a directory.
+    ///     Checks if the item in the keyed box is a file.
     /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [ExcludeFromCodeCoverage]
-    public static bool IsDirectory<TSelf>(this TSelf item)
-        where TSelf : struct, IHaveAFileOrDirectory =>
-        item.IsDirectory;
+    /// <param name="item">The keyed box containing the item to check.</param>
+    /// <returns>True if the item is a file; otherwise, false.</returns>
+    public static bool IsFile<TSelf, TKey>(this KeyedBox<TKey, TSelf> item)
+        where TSelf : struct, IHaveAFileOrDirectory
+        where TKey : notnull
+        => item.Item.IsFile;
+
+    /// <summary>
+    ///     Checks if the item in the box is a file.
+    /// </summary>
+    /// <param name="item">The box containing the item to check.</param>
+    /// <returns>True if the item is a file; otherwise, false.</returns>
+    public static bool IsFile<TSelf>(this Box<TSelf> item)
+        where TSelf : struct, IHaveAFileOrDirectory
+        => item.Item.IsFile;
+
+    /// <summary>
+    ///     Checks if the item in the keyed box is a directory.
+    /// </summary>
+    /// <param name="item">The keyed box containing the item to check.</param>
+    /// <returns>True if the item is a directory; otherwise, false.</returns>
+    public static bool IsDirectory<TSelf, TKey>(this KeyedBox<TKey, TSelf> item)
+        where TSelf : struct, IHaveAFileOrDirectory
+        where TKey : notnull
+        => item.Item.IsDirectory;
+
+    /// <summary>
+    ///     Checks if the item in the box is a directory.
+    /// </summary>
+    /// <param name="item">The box containing the item to check.</param>
+    /// <returns>True if the item is a directory; otherwise, false.</returns>
+    public static bool IsDirectory<TSelf>(this Box<TSelf> item)
+        where TSelf : struct, IHaveAFileOrDirectory
+        => item.Item.IsDirectory;
 }

--- a/src/NexusMods.Paths/Trees/Traits/IHaveAFileOrDirectory.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveAFileOrDirectory.cs
@@ -558,7 +558,7 @@ public static class IHaveAFileOrDirectoryExtensionsForIHaveObservableChildren
     /// <returns>An IEnumerable of all child nodes of the current node that are files, enumerated in a breadth-first manner.</returns>
     public static IEnumerable<Box<TSelf>> EnumerateFilesBfs<TSelf>(this TSelf item)
         where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveAFileOrDirectory
-        => item.EnumerateChildrenFilteredBfs<TSelf, BoxFileFilter<TSelf>>();
+        => item.EnumerateChildrenBfs<TSelf, BoxFileFilter<TSelf>>();
 
     /// <summary>
     ///     Enumerates all file child nodes of the current node in a breadth-first manner.
@@ -578,7 +578,7 @@ public static class IHaveAFileOrDirectoryExtensionsForIHaveObservableChildren
     /// <returns>An IEnumerable of all child nodes of the current node that are directories, enumerated in a breadth-first manner.</returns>
     public static IEnumerable<Box<TSelf>> EnumerateDirectoriesBfs<TSelf>(this TSelf item)
         where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveAFileOrDirectory
-        => item.EnumerateChildrenFilteredBfs<TSelf, BoxDirectoryFilter<TSelf>>();
+        => item.EnumerateChildrenBfs<TSelf, BoxDirectoryFilter<TSelf>>();
 
     /// <summary>
     ///     Enumerates all directory child nodes of the current node in a breadth-first manner.
@@ -598,7 +598,7 @@ public static class IHaveAFileOrDirectoryExtensionsForIHaveObservableChildren
     /// <returns>An IEnumerable of all child nodes of the current node that are files, enumerated in a depth-first manner.</returns>
     public static IEnumerable<Box<TSelf>> EnumerateFilesDfs<TSelf>(this TSelf item)
         where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveAFileOrDirectory
-        => item.EnumerateChildrenFilteredDfs<TSelf, BoxFileFilter<TSelf>>();
+        => item.EnumerateChildrenDfs<TSelf, BoxFileFilter<TSelf>>();
 
     /// <summary>
     ///     Enumerates all file child nodes of the current node in a depth-first manner.
@@ -618,7 +618,7 @@ public static class IHaveAFileOrDirectoryExtensionsForIHaveObservableChildren
     /// <returns>An IEnumerable of all child nodes of the current node that are directories, enumerated in a depth-first manner.</returns>
     public static IEnumerable<Box<TSelf>> EnumerateDirectoriesDfs<TSelf>(this TSelf item)
         where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveAFileOrDirectory
-        => item.EnumerateChildrenFilteredDfs<TSelf, BoxDirectoryFilter<TSelf>>();
+        => item.EnumerateChildrenDfs<TSelf, BoxDirectoryFilter<TSelf>>();
 
     /// <summary>
     ///     Enumerates all directory child nodes of the current node in a depth-first manner.

--- a/src/NexusMods.Paths/Trees/Traits/IHaveAFileOrDirectory.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveAFileOrDirectory.cs
@@ -1,5 +1,7 @@
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using NexusMods.Paths.Trees.Traits.Interfaces;
 
 namespace NexusMods.Paths.Trees.Traits;
 
@@ -107,6 +109,102 @@ public static class IHaveAFileOrDirectoryExtensionsForIHaveBoxedChildrenWithKey
             child.Value.Item.CountDirectoriesRecursive<TSelf, TKey>(ref accumulator);
         }
     }
+
+    /// <summary>
+    ///     Enumerates all file child nodes of the current node in a breadth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose file children are to be enumerated.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are files, enumerated in a breadth-first manner.</returns>
+    public static IEnumerable<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>> EnumerateFilesBfs<TSelf, TKey>(this TSelf item)
+        where TKey : notnull
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveAFileOrDirectory
+        => item.EnumerateChildrenFilteredBfs<TSelf, TKey, KeyedBoxFileFilter<TSelf, TKey>>(new KeyedBoxFileFilter<TSelf, TKey>());
+
+    /// <summary>
+    ///     Enumerates all file child nodes of the current node in a breadth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose file children are to be enumerated.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are files, enumerated in a breadth-first manner.</returns>
+    public static IEnumerable<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>> EnumerateFilesBfs<TSelf, TKey>(this KeyedBox<TKey, TSelf> item)
+        where TKey : notnull
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveAFileOrDirectory
+        => item.Item.EnumerateFilesBfs<TSelf, TKey>();
+
+    /// <summary>
+    ///     Enumerates all directory child nodes of the current node in a breadth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose directory children are to be enumerated.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are directories, enumerated in a breadth-first manner.</returns>
+    public static IEnumerable<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>> EnumerateDirectoriesBfs<TSelf, TKey>(this TSelf item)
+        where TKey : notnull
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveAFileOrDirectory
+        => item.EnumerateChildrenFilteredBfs<TSelf, TKey, KeyedBoxDirectoryFilter<TSelf, TKey>>(new KeyedBoxDirectoryFilter<TSelf, TKey>());
+
+    /// <summary>
+    ///     Enumerates all directory child nodes of the current node in a breadth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose directory children are to be enumerated.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are directories, enumerated in a breadth-first manner.</returns>
+    public static IEnumerable<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>> EnumerateDirectoriesBfs<TSelf, TKey>(this KeyedBox<TKey, TSelf> item)
+        where TKey : notnull
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveAFileOrDirectory
+        => item.Item.EnumerateDirectoriesBfs<TSelf, TKey>();
+
+    /// <summary>
+    ///     Enumerates all file child nodes of the current node in a depth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose file children are to be enumerated.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are files, enumerated in a depth-first manner.</returns>
+    public static IEnumerable<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>> EnumerateFilesDfs<TSelf, TKey>(this TSelf item)
+        where TKey : notnull
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveAFileOrDirectory
+        => item.EnumerateChildrenFilteredDfs<TSelf, TKey, KeyedBoxFileFilter<TSelf, TKey>>(new KeyedBoxFileFilter<TSelf, TKey>());
+
+    /// <summary>
+    ///     Enumerates all file child nodes of the current node in a depth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose file children are to be enumerated.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are files, enumerated in a depth-first manner.</returns>
+    public static IEnumerable<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>> EnumerateFilesDfs<TSelf, TKey>(this KeyedBox<TKey, TSelf> item)
+        where TKey : notnull
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveAFileOrDirectory
+        => item.Item.EnumerateFilesDfs<TSelf, TKey>();
+
+    /// <summary>
+    ///     Enumerates all directory child nodes of the current node in a depth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose directory children are to be enumerated.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are directories, enumerated in a depth-first manner.</returns>
+    public static IEnumerable<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>> EnumerateDirectoriesDfs<TSelf, TKey>(this TSelf item)
+        where TKey : notnull
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveAFileOrDirectory
+        => item.EnumerateChildrenFilteredDfs<TSelf, TKey, KeyedBoxDirectoryFilter<TSelf, TKey>>(new KeyedBoxDirectoryFilter<TSelf, TKey>());
+
+    /// <summary>
+    ///     Enumerates all directory child nodes of the current node in a depth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose directory children are to be enumerated.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are directories, enumerated in a depth-first manner.</returns>
+    public static IEnumerable<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>> EnumerateDirectoriesDfs<TSelf, TKey>(this KeyedBox<TKey, TSelf> item)
+        where TKey : notnull
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveAFileOrDirectory
+        => item.Item.EnumerateDirectoriesDfs<TSelf, TKey>();
 }
 
 /// <summary>
@@ -191,6 +289,86 @@ public static class IHaveAFileOrDirectoryExtensionsForIHaveBoxedChildren
             child.Item.CountDirectoriesRecursive(ref accumulator);
         }
     }
+
+    /// <summary>
+    ///     Enumerates all file child nodes of the current node in a breadth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose file children are to be enumerated.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are files, enumerated in a breadth-first manner.</returns>
+    public static IEnumerable<Box<TSelf>> EnumerateFilesBfs<TSelf>(this TSelf item)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveAFileOrDirectory
+        => item.EnumerateChildrenFilteredBfs(new BoxFileFilter<TSelf>());
+
+    /// <summary>
+    ///     Enumerates all file child nodes of the current node in a breadth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose file children are to be enumerated.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are files, enumerated in a breadth-first manner.</returns>
+    public static IEnumerable<Box<TSelf>> EnumerateFilesBfs<TSelf>(this Box<TSelf> item)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveAFileOrDirectory
+        => item.Item.EnumerateFilesBfs();
+
+    /// <summary>
+    ///     Enumerates all directory child nodes of the current node in a breadth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose directory children are to be enumerated.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are directories, enumerated in a breadth-first manner.</returns>
+    public static IEnumerable<Box<TSelf>> EnumerateDirectoriesBfs<TSelf>(this TSelf item)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveAFileOrDirectory
+        => item.EnumerateChildrenFilteredBfs(new BoxDirectoryFilter<TSelf>());
+
+    /// <summary>
+    ///     Enumerates all directory child nodes of the current node in a breadth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose file children are to be enumerated.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are directories, enumerated in a depth-first manner.</returns>
+    public static IEnumerable<Box<TSelf>> EnumerateDirectoriesBfs<TSelf>(this Box<TSelf> item)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveAFileOrDirectory
+        => item.Item.EnumerateDirectoriesBfs();
+
+    /// <summary>
+    ///     Enumerates all file child nodes of the current node in a depth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose file children are to be enumerated.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are files, enumerated in a depth-first manner.</returns>
+    public static IEnumerable<Box<TSelf>> EnumerateFilesDfs<TSelf>(this TSelf item)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveAFileOrDirectory
+        => item.EnumerateChildrenFilteredDfs(new BoxFileFilter<TSelf>());
+
+    /// <summary>
+    ///     Enumerates all file child nodes of the current node in a depth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose file children are to be enumerated.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are files, enumerated in a depth-first manner.</returns>
+    public static IEnumerable<Box<TSelf>> EnumerateFilesDfs<TSelf>(this Box<TSelf> item)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveAFileOrDirectory
+        => item.Item.EnumerateFilesDfs();
+
+    /// <summary>
+    ///     Enumerates all directory child nodes of the current node in a depth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose file children are to be enumerated.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are directories, enumerated in a depth-first manner.</returns>
+    public static IEnumerable<Box<TSelf>> EnumerateDirectoriesDfs<TSelf>(this TSelf item)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveAFileOrDirectory
+        => item.EnumerateChildrenFilteredDfs(new BoxDirectoryFilter<TSelf>());
+
+    /// <summary>
+    ///     Enumerates all directory child nodes of the current node in a depth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose file children are to be enumerated.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are directories, enumerated in a depth-first manner.</returns>
+    public static IEnumerable<Box<TSelf>> EnumerateDirectoriesDfs<TSelf>(this Box<TSelf> item)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveAFileOrDirectory
+        => item.Item.EnumerateDirectoriesDfs();
 }
 
 /// <summary>
@@ -275,6 +453,86 @@ public static class IHaveAFileOrDirectoryExtensionsForIHaveObservableChildren
             child.Item.CountDirectoriesRecursive(ref accumulator);
         }
     }
+
+    /// <summary>
+    ///     Enumerates all file child nodes of the current node in a breadth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose file children are to be enumerated.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are files, enumerated in a breadth-first manner.</returns>
+    public static IEnumerable<Box<TSelf>> EnumerateFilesBfs<TSelf>(this TSelf item)
+        where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveAFileOrDirectory
+        => item.EnumerateChildrenFilteredBfs(new BoxFileFilter<TSelf>());
+
+    /// <summary>
+    ///     Enumerates all file child nodes of the current node in a breadth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose file children are to be enumerated.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are files, enumerated in a breadth-first manner.</returns>
+    public static IEnumerable<Box<TSelf>> EnumerateFilesBfs<TSelf>(this Box<TSelf> item)
+        where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveAFileOrDirectory
+        => item.Item.EnumerateFilesBfs();
+
+    /// <summary>
+    ///     Enumerates all directory child nodes of the current node in a breadth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose directory children are to be enumerated.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are directories, enumerated in a breadth-first manner.</returns>
+    public static IEnumerable<Box<TSelf>> EnumerateDirectoriesBfs<TSelf>(this TSelf item)
+        where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveAFileOrDirectory
+        => item.EnumerateChildrenFilteredBfs(new BoxDirectoryFilter<TSelf>());
+
+    /// <summary>
+    ///     Enumerates all directory child nodes of the current node in a breadth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose file children are to be enumerated.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are directories, enumerated in a depth-first manner.</returns>
+    public static IEnumerable<Box<TSelf>> EnumerateDirectoriesBfs<TSelf>(this Box<TSelf> item)
+        where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveAFileOrDirectory
+        => item.Item.EnumerateDirectoriesBfs();
+
+    /// <summary>
+    ///     Enumerates all file child nodes of the current node in a depth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose file children are to be enumerated.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are files, enumerated in a depth-first manner.</returns>
+    public static IEnumerable<Box<TSelf>> EnumerateFilesDfs<TSelf>(this TSelf item)
+        where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveAFileOrDirectory
+        => item.EnumerateChildrenFilteredDfs(new BoxFileFilter<TSelf>());
+
+    /// <summary>
+    ///     Enumerates all file child nodes of the current node in a depth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose file children are to be enumerated.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are files, enumerated in a depth-first manner.</returns>
+    public static IEnumerable<Box<TSelf>> EnumerateFilesDfs<TSelf>(this Box<TSelf> item)
+        where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveAFileOrDirectory
+        => item.Item.EnumerateFilesDfs();
+
+    /// <summary>
+    ///     Enumerates all directory child nodes of the current node in a depth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose file children are to be enumerated.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are directories, enumerated in a depth-first manner.</returns>
+    public static IEnumerable<Box<TSelf>> EnumerateDirectoriesDfs<TSelf>(this TSelf item)
+        where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveAFileOrDirectory
+        => item.EnumerateChildrenFilteredDfs(new BoxDirectoryFilter<TSelf>());
+
+    /// <summary>
+    ///     Enumerates all directory child nodes of the current node in a depth-first manner.
+    /// </summary>
+    /// <param name="item">The node whose file children are to be enumerated.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An IEnumerable of all child nodes of the current node that are directories, enumerated in a depth-first manner.</returns>
+    public static IEnumerable<Box<TSelf>> EnumerateDirectoriesDfs<TSelf>(this Box<TSelf> item)
+        where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveAFileOrDirectory
+        => item.Item.EnumerateDirectoriesDfs();
 }
 
 /// <summary>
@@ -322,3 +580,28 @@ public static class IHaveAFileOrDirectoryExtensions
         where TSelf : struct, IHaveAFileOrDirectory
         => item.Item.IsDirectory;
 }
+
+internal struct BoxFileFilter<TSelf> : IFilter<Box<TSelf>> where TSelf : struct, IHaveAFileOrDirectory
+{
+    public bool Match(Box<TSelf> item) => item.Item.IsFile;
+}
+
+internal struct BoxDirectoryFilter<TSelf> : IFilter<Box<TSelf>> where TSelf : struct, IHaveAFileOrDirectory
+{
+    public bool Match(Box<TSelf> item) => item.Item.IsDirectory;
+}
+
+internal struct KeyedBoxFileFilter<TSelf, TKey> : IFilter<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>>
+    where TSelf : struct, IHaveAFileOrDirectory
+    where TKey : notnull
+{
+    public bool Match(KeyValuePair<TKey, KeyedBox<TKey, TSelf>> item) => item.Value.Item.IsFile;
+}
+
+internal struct KeyedBoxDirectoryFilter<TSelf, TKey> : IFilter<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>>
+    where TSelf : struct, IHaveAFileOrDirectory
+    where TKey : notnull
+{
+    public bool Match(KeyValuePair<TKey, KeyedBox<TKey, TSelf>> item) => item.Value.Item.IsDirectory;
+}
+

--- a/src/NexusMods.Paths/Trees/Traits/IHaveAFileOrDirectory.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveAFileOrDirectory.cs
@@ -730,6 +730,18 @@ public static class IHaveAFileOrDirectoryExtensions
     ///     Checks if the item in the keyed box is a file.
     /// </summary>
     /// <param name="item">The keyed box containing the item to check.</param>
+    /// <typeparam name="TSelf">The type of the child node.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <returns>True if the item is a file; otherwise, false.</returns>
+    public static bool IsFile<TSelf, TKey>(this KeyValuePair<TKey, KeyedBox<TKey, TSelf>> item)
+        where TSelf : struct, IHaveAFileOrDirectory
+        where TKey : notnull
+        => item.Value.Item.IsFile;
+
+    /// <summary>
+    ///     Checks if the item in the keyed box is a file.
+    /// </summary>
+    /// <param name="item">The keyed box containing the item to check.</param>
     /// <returns>True if the item is a file; otherwise, false.</returns>
     public static bool IsFile<TSelf, TKey>(this KeyedBox<TKey, TSelf> item)
         where TSelf : struct, IHaveAFileOrDirectory
@@ -744,6 +756,16 @@ public static class IHaveAFileOrDirectoryExtensions
     public static bool IsFile<TSelf>(this Box<TSelf> item)
         where TSelf : struct, IHaveAFileOrDirectory
         => item.Item.IsFile;
+
+    /// <summary>
+    ///     Checks if the item in the keyed box is a directory.
+    /// </summary>
+    /// <param name="item">The keyed box containing the item to check.</param>
+    /// <returns>True if the item is a directory; otherwise, false.</returns>
+    public static bool IsDirectory<TSelf, TKey>(this KeyValuePair<TKey, KeyedBox<TKey, TSelf>> item)
+        where TSelf : struct, IHaveAFileOrDirectory
+        where TKey : notnull
+        => item.Value.Item.IsDirectory;
 
     /// <summary>
     ///     Checks if the item in the keyed box is a directory.

--- a/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildren.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildren.cs
@@ -99,36 +99,34 @@ public static class IHaveBoxedChildrenExtensions
     ///     Enumerates all child nodes of the current node in a breadth-first manner that satisfy a given filter.
     /// </summary>
     /// <param name="item">The node, wrapped in a Box, whose children are to be enumerated.</param>
-    /// <param name="filter">The filter struct to be applied to each child node.</param>
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
     /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
     [ExcludeFromCodeCoverage] // Wrapper
-    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredBfs<TSelf, TFilter>(this Box<TSelf> item, TFilter filter)
+    public static IEnumerable<Box<TSelf>> EnumerateChildrenBfs<TSelf, TFilter>(this Box<TSelf> item)
         where TSelf : struct, IHaveBoxedChildren<TSelf>
         where TFilter : struct, IFilter<Box<TSelf>>
-        => item.Item.EnumerateChildrenFilteredBfs(filter);
+        => item.Item.EnumerateChildrenBfs<TSelf, TFilter>();
 
     /// <summary>
     ///     Enumerates all child nodes of the current node in a breadth-first manner that satisfy a given filter.
     /// </summary>
     /// <param name="item">The node whose children are to be enumerated.</param>
-    /// <param name="filter">The filter struct to be applied to each child node.</param>
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
     /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
-    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredBfs<TSelf, TFilter>(this TSelf item, TFilter filter)
+    public static IEnumerable<Box<TSelf>> EnumerateChildrenBfs<TSelf, TFilter>(this TSelf item)
         where TSelf : struct, IHaveBoxedChildren<TSelf>
         where TFilter : struct, IFilter<Box<TSelf>>
     {
         // Return the current item's immediate children first if they match the filter.
         foreach (var child in item.Children)
-            if (filter.Match(child))
+            if (TFilter.Match(child))
                 yield return child;
 
         // Then return the filtered children of those children.
         foreach (var child in item.Children)
-        foreach (var grandChild in child.Item.EnumerateChildrenFilteredBfs(filter))
+        foreach (var grandChild in child.Item.EnumerateChildrenBfs<TSelf, TFilter>())
             yield return grandChild;
     }
 
@@ -136,34 +134,32 @@ public static class IHaveBoxedChildrenExtensions
     ///     Enumerates all child nodes of the current node in a depth-first manner that satisfy a given filter.
     /// </summary>
     /// <param name="item">The node, wrapped in a Box, whose children are to be enumerated.</param>
-    /// <param name="filter">The filter struct to be applied to each child node.</param>
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
     /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
     [ExcludeFromCodeCoverage] // Wrapper
-    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredDfs<TSelf, TFilter>(this Box<TSelf> item, TFilter filter)
+    public static IEnumerable<Box<TSelf>> EnumerateChildrenDfs<TSelf, TFilter>(this Box<TSelf> item)
         where TSelf : struct, IHaveBoxedChildren<TSelf>
         where TFilter : struct, IFilter<Box<TSelf>>
-        => item.Item.EnumerateChildrenFilteredDfs(filter);
+        => item.Item.EnumerateChildrenDfs<TSelf, TFilter>();
 
     /// <summary>
     ///     Enumerates all child nodes of the current node in a depth-first manner that satisfy a given filter.
     /// </summary>
     /// <param name="item">The node whose children are to be enumerated.</param>
-    /// <param name="filter">The filter struct to be applied to each child node.</param>
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
     /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
-    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredDfs<TSelf, TFilter>(this TSelf item, TFilter filter)
+    public static IEnumerable<Box<TSelf>> EnumerateChildrenDfs<TSelf, TFilter>(this TSelf item)
         where TSelf : struct, IHaveBoxedChildren<TSelf>
         where TFilter : struct, IFilter<Box<TSelf>>
     {
         foreach (var child in item.Children)
         {
-            if (filter.Match(child))
+            if (TFilter.Match(child))
                 yield return child;
 
-            foreach (var grandChild in child.Item.EnumerateChildrenFilteredDfs(filter))
+            foreach (var grandChild in child.Item.EnumerateChildrenDfs<TSelf, TFilter>())
                 yield return grandChild;
         }
     }
@@ -172,45 +168,43 @@ public static class IHaveBoxedChildrenExtensions
     ///     Counts the number of children that match the given filter under this node.
     /// </summary>
     /// <param name="item">The node whose children are to be counted.</param>
-    /// <param name="filter">The filter to apply to each child.</param>
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TFilter">The type of the filter.</typeparam>
     /// <returns>The total count of children that match the filter under this node.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [ExcludeFromCodeCoverage]
-    public static int CountChildren<TSelf, TFilter>(this Box<TSelf> item, TFilter filter)
+    public static int CountChildren<TSelf, TFilter>(this Box<TSelf> item)
         where TSelf : struct, IHaveBoxedChildren<TSelf>
         where TFilter : struct, IFilter<TSelf>
-        => item.Item.CountChildren(filter);
+        => item.Item.CountChildren<TSelf, TFilter>();
 
     /// <summary>
     ///     Counts the number of children that match the given filter under this node.
     /// </summary>
     /// <param name="item">The node whose children are to be counted.</param>
-    /// <param name="filter">The filter to apply to each child.</param>
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TFilter">The type of the filter.</typeparam>
     /// <returns>The total count of children that match the filter under this node.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int CountChildren<TSelf, TFilter>(this TSelf item, TFilter filter)
+    public static int CountChildren<TSelf, TFilter>(this TSelf item)
         where TSelf : struct, IHaveBoxedChildren<TSelf>
         where TFilter : struct, IFilter<TSelf>
     {
         var result = 0;
-        item.CountChildrenRecursive(ref result, filter);
+        item.CountChildrenRecursive<TSelf, TFilter>(ref result);
         return result;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void CountChildrenRecursive<TSelf, TFilter>(this TSelf item, ref int accumulator, TFilter filter)
+    private static void CountChildrenRecursive<TSelf, TFilter>(this TSelf item, ref int accumulator)
         where TSelf : struct, IHaveBoxedChildren<TSelf>
         where TFilter : struct, IFilter<TSelf>
     {
         foreach (var child in item.Children)
         {
-            var matchesFilter = filter.Match(child.Item);
+            var matchesFilter = TFilter.Match(child.Item);
             accumulator += Unsafe.As<bool, byte>(ref matchesFilter); // Branchless increment.
-            child.Item.CountChildrenRecursive(ref accumulator, filter);
+            child.Item.CountChildrenRecursive<TSelf, TFilter>(ref accumulator);
         }
     }
 
@@ -251,34 +245,32 @@ public static class IHaveBoxedChildrenExtensions
     ///     Recursively returns all the child items of this node selected by the given selector.
     /// </summary>
     /// <param name="item">The boxed node whose child items to obtain.</param>
-    /// <param name="selector">The selector to determine which child items to return.</param>
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <typeparam name="TSelector">The type of the selector.</typeparam>
     /// <returns>An array of all the selected child items of this node.</returns>
     [ExcludeFromCodeCoverage]
-    public static TResult[] GetChildItems<TSelf, TResult, TSelector>(this Box<TSelf> item, TSelector selector)
+    public static TResult[] GetChildrenRecursive<TSelf, TResult, TSelector>(this Box<TSelf> item)
         where TSelf : struct, IHaveBoxedChildren<TSelf>
         where TSelector : struct, ISelector<TSelf, TResult>
-        => item.Item.GetChildItems<TSelf, TResult, TSelector>(selector);
+        => item.Item.GetChildrenRecursive<TSelf, TResult, TSelector>();
 
     /// <summary>
     ///     Recursively returns all the child items of this node selected by the given selector.
     /// </summary>
     /// <param name="item">The node whose child items to obtain.</param>
-    /// <param name="selector">The selector to determine which child items to return.</param>
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <typeparam name="TSelector">The type of the selector.</typeparam>
     /// <returns>An array of all the selected child items of this node.</returns>
-    public static TResult[] GetChildItems<TSelf, TResult, TSelector>(this TSelf item, TSelector selector)
+    public static TResult[] GetChildrenRecursive<TSelf, TResult, TSelector>(this TSelf item)
         where TSelf : struct, IHaveBoxedChildren<TSelf>
         where TSelector : struct, ISelector<TSelf, TResult>
     {
-        var totalValues = item.CountChildren(); // Ensure this method counts all descendants.
+        var totalValues = item.CountChildren();
         var results = GC.AllocateUninitializedArray<TResult>(totalValues);
         var index = 0;
-        GetChildItemsUnsafe<TSelf, TResult, TSelector>(item, selector, results, ref index);
+        GetChildrenRecursiveUnsafe<TSelf, TResult, TSelector>(item, results, ref index);
         return results;
     }
 
@@ -286,22 +278,90 @@ public static class IHaveBoxedChildrenExtensions
     ///     Helper method to populate child items recursively.
     /// </summary>
     /// <param name="item">The current node.</param>
-    /// <param name="selector">The selector to determine which child items to return.</param>
     /// <param name="buffer">
     ///     The span to fill with child items.
     ///     Should be at least as big as <see cref="IHaveBoxedChildrenExtensions.CountChildren{TSelf}(Box{TSelf})"/>
     /// </param>
     /// <param name="index">The current index in the array.</param>
-    public static void GetChildItemsUnsafe<TSelf, TResult, TSelector>(this TSelf item, TSelector selector, Span<TResult> buffer, ref int index)
+    public static void GetChildrenRecursiveUnsafe<TSelf, TResult, TSelector>(this TSelf item, Span<TResult> buffer, ref int index)
         where TSelf : struct, IHaveBoxedChildren<TSelf>
         where TSelector : struct, ISelector<TSelf, TResult>
     {
         // Populate breadth first. Improved cache locality helps here.
         foreach (var child in item.Children)
-            buffer.DangerousGetReferenceAt(index++) = selector.Select(child.Item);
+            buffer.DangerousGetReferenceAt(index++) = TSelector.Select(child.Item);
 
         foreach (var child in item.Children)
-            GetChildItemsUnsafe(child.Item, selector, buffer, ref index);
+            GetChildrenRecursiveUnsafe<TSelf, TResult, TSelector>(child.Item, buffer, ref index);
+    }
+
+    /// <summary>
+    ///     Recursively returns all the child items of this node that match the given filter, transformed by the selector.
+    /// </summary>
+    /// <param name="item">The boxed node whose child items to obtain.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An array of all the transformed child items of this node that match the filter.</returns>
+    public static TResult[] GetChildrenRecursive<TSelf, TResult, TFilter, TSelector>(this Box<TSelf> item)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TFilter : struct, IFilter<TSelf>
+        where TSelector : struct, ISelector<TSelf, TResult>
+        => item.Item.GetChildrenRecursive<TSelf, TResult, TFilter, TSelector>();
+
+    /// <summary>
+    /// Recursively returns all the child items of this node that match the given filter, transformed by the selector.
+    /// </summary>
+    /// <param name="item">The node whose child items to obtain.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An array of all the transformed child items of this node that match the filter.</returns>
+    public static TResult[] GetChildrenRecursive<TSelf, TResult, TFilter, TSelector>(this TSelf item)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TFilter : struct, IFilter<TSelf>
+        where TSelector : struct, ISelector<TSelf, TResult>
+    {
+        var totalChildren = item.CountChildren<TSelf, TFilter>();
+        var results = GC.AllocateUninitializedArray<TResult>(totalChildren);
+        var index = 0;
+        GetChildrenRecursiveUnsafe<TSelf, TResult, TFilter, TSelector>(item, results, ref index);
+        return results;
+    }
+
+    /// <summary>
+    ///     Helper method to populate transformed child items recursively, filtered by the given filter.
+    /// </summary>
+    /// <param name="item">The current node.</param>
+    /// <param name="buffer">The span to fill with transformed child items.</param>
+    /// <param name="index">The current index in the span.</param>
+    public static void GetChildrenRecursiveUnsafe<TSelf, TResult, TFilter, TSelector>(this Box<TSelf> item,
+        Span<TResult> buffer, ref int index)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TFilter : struct, IFilter<TSelf>
+        where TSelector : struct, ISelector<TSelf, TResult>
+        => item.Item.GetChildrenRecursiveUnsafe<TSelf, TResult, TFilter, TSelector>(buffer, ref index);
+
+    /// <summary>
+    ///     Helper method to populate transformed child items recursively, filtered by the given filter.
+    /// </summary>
+    /// <param name="item">The current node.</param>
+    /// <param name="buffer">The span to fill with transformed child items.</param>
+    /// <param name="index">The current index in the span.</param>
+    public static void GetChildrenRecursiveUnsafe<TSelf, TResult, TFilter, TSelector>(this TSelf item, Span<TResult> buffer, ref int index)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TFilter : struct, IFilter<TSelf>
+        where TSelector : struct, ISelector<TSelf, TResult>
+    {
+        foreach (var child in item.Children)
+        {
+            if (TFilter.Match(child.Item))
+                buffer.DangerousGetReferenceAt(index++) = TSelector.Select(child.Item);
+
+            GetChildrenRecursiveUnsafe<TSelf, TResult, TFilter, TSelector>(child.Item, buffer, ref index);
+        }
     }
 
     /// <summary>
@@ -348,6 +408,60 @@ public static class IHaveBoxedChildrenExtensions
 
         foreach (var child in item.Children)
             GetChildrenRecursiveUnsafe(child.Item, childrenSpan, ref index);
+    }
+
+    /// <summary>
+    ///     Recursively returns all the children of this node that match the given filter.
+    /// </summary>
+    /// <param name="item">The node whose children to obtain.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">Filter to apply that decides which children should be returned.</typeparam>
+    /// <returns>An array of all the children of this node that match the filter.</returns>
+    [ExcludeFromCodeCoverage]
+    public static Box<TSelf>[] GetChildrenRecursive<TSelf, TFilter>(this Box<TSelf> item)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TFilter : struct, IFilter<TSelf>
+        => item.Item.GetChildrenRecursive();
+
+    /// <summary>
+    ///     Recursively returns all the children of this node that match the given filter.
+    /// </summary>
+    /// <param name="item">The node whose children to obtain.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">Filter to apply that decides which children should be returned.</typeparam>
+    /// <returns>An array of all the children of this node that match the filter.</returns>
+    public static Box<TSelf>[] GetChildrenRecursive<TSelf, TFilter>(this TSelf item)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TFilter : struct, IFilter<TSelf>
+    {
+        var totalChildren = item.CountChildren<TSelf, TFilter>();
+        var children = GC.AllocateUninitializedArray<Box<TSelf>>(totalChildren);
+        var index = 0;
+        GetChildrenRecursiveUnsafe<TSelf, TFilter>(item, children, ref index);
+        return children;
+    }
+
+    /// <summary>
+    ///     Recursively returns all the children of this node (unsafe / no bounds checks).
+    /// </summary>
+    /// <param name="item">The current node.</param>
+    /// <param name="childrenSpan">
+    ///     The span representing the array to fill with children.
+    ///     Should be at least as long as the value returned by <see cref="CountChildren{TSelf,TFilter}(NexusMods.Paths.Trees.Box{TSelf})"/>
+    /// </param>
+    /// <param name="index">The current index in the span.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void GetChildrenRecursiveUnsafe<TSelf, TFilter>(this TSelf item, Span<Box<TSelf>> childrenSpan, ref int index)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TFilter : struct, IFilter<TSelf>
+    {
+        foreach (var child in item.Children)
+        {
+            if (TFilter.Match(child.Item))
+                childrenSpan.DangerousGetReferenceAt(index++) = child;
+
+            GetChildrenRecursiveUnsafe(child.Item, childrenSpan, ref index);
+        }
     }
 
     /// <summary>

--- a/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildren.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildren.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Reloaded.Memory.Extensions;
 
@@ -254,4 +255,15 @@ public static class IHaveBoxedChildrenExtensions
                 GetLeavesUnsafe(child.Item, leavesSpan, ref index);
         }
     }
+
+    /// <summary>
+    ///     Retrieves the direct children of the current node.
+    /// </summary>
+    /// <param name="item">The node whose children are to be retrieved.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <returns>An array of the direct children of the current node.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static Box<TSelf>[] Children<TSelf>(this Box<TSelf> item)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        => item.Item.Children;
 }

--- a/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildren.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildren.cs
@@ -172,6 +172,7 @@ public static class IHaveBoxedChildrenExtensions
     /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
     /// <typeparam name="TSelector">The type of the selector.</typeparam>
     /// <returns>An IEnumerable of transformed child nodes of the current node.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
     public static IEnumerable<TResult> EnumerateChildrenBfs<TSelf, TResult, TSelector>(this Box<TSelf> item)
         where TSelf : struct, IHaveBoxedChildren<TSelf>
         where TSelector : struct, ISelector<Box<TSelf>, TResult>
@@ -207,6 +208,7 @@ public static class IHaveBoxedChildrenExtensions
     /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
     /// <typeparam name="TSelector">The type of the selector.</typeparam>
     /// <returns>An IEnumerable of transformed child nodes of the current node.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
     public static IEnumerable<TResult> EnumerateChildrenDfs<TSelf, TResult, TSelector>(this Box<TSelf> item)
         where TSelf : struct, IHaveBoxedChildren<TSelf>
         where TSelector : struct, ISelector<Box<TSelf>, TResult>

--- a/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildren.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildren.cs
@@ -165,6 +165,157 @@ public static class IHaveBoxedChildrenExtensions
     }
 
     /// <summary>
+    ///     Enumerates all child nodes of the current node in a breadth-first manner, transforming each child node using the provided selector.
+    /// </summary>
+    /// <param name="item">The node whose children are to be enumerated and transformed.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed child nodes of the current node.</returns>
+    public static IEnumerable<TResult> EnumerateChildrenBfs<TSelf, TResult, TSelector>(this Box<TSelf> item)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TSelector : struct, ISelector<Box<TSelf>, TResult>
+        => item.Item.EnumerateChildrenBfs<TSelf, TResult, TSelector>();
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a breadth-first manner, transforming each child node using the provided selector.
+    /// </summary>
+    /// <param name="item">The node whose children are to be enumerated and transformed.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed child nodes of the current node.</returns>
+    public static IEnumerable<TResult> EnumerateChildrenBfs<TSelf, TResult, TSelector>(this TSelf item)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TSelector : struct, ISelector<Box<TSelf>, TResult>
+    {
+        // Return the current item's immediate children first.
+        foreach (var child in item.Children)
+            yield return TSelector.Select(child);
+
+        // Then return the children of those children.
+        foreach (var child in item.Children)
+        foreach (var grandChild in child.Item.EnumerateChildrenBfs<TSelf, TResult, TSelector>())
+            yield return grandChild;
+    }
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a depth-first manner, transforming each child node using the provided selector.
+    /// </summary>
+    /// <param name="item">The node whose children are to be enumerated and transformed.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed child nodes of the current node.</returns>
+    public static IEnumerable<TResult> EnumerateChildrenDfs<TSelf, TResult, TSelector>(this Box<TSelf> item)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TSelector : struct, ISelector<Box<TSelf>, TResult>
+        => item.Item.EnumerateChildrenDfs<TSelf, TResult, TSelector>();
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a depth-first manner, transforming each child node using the provided selector.
+    /// </summary>
+    /// <param name="item">The node whose children are to be enumerated and transformed.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed child nodes of the current node.</returns>
+    public static IEnumerable<TResult> EnumerateChildrenDfs<TSelf, TResult, TSelector>(this TSelf item)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TSelector : struct, ISelector<Box<TSelf>, TResult>
+    {
+        foreach (var child in item.Children)
+        {
+            yield return TSelector.Select(child);
+            foreach (var grandChild in child.Item.EnumerateChildrenDfs<TSelf, TResult, TSelector>())
+                yield return grandChild;
+        }
+    }
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a breadth-first manner that satisfy a given filter,
+    ///     transforming each filtered child node using the provided selector.
+    /// </summary>
+    /// <param name="item">The node, wrapped in a Box, whose filtered children are to be enumerated and transformed.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed and filtered child nodes of the current node.</returns>
+    public static IEnumerable<TResult> EnumerateChildrenBfs<TSelf, TResult, TFilter, TSelector>(this Box<TSelf> item)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TFilter : struct, IFilter<Box<TSelf>>
+        where TSelector : struct, ISelector<Box<TSelf>, TResult>
+        => item.Item.EnumerateChildrenBfs<TSelf, TResult, TFilter, TSelector>();
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a breadth-first manner that satisfy a given filter,
+    ///     transforming each filtered child node using the provided selector.
+    /// </summary>
+    /// <param name="item">The node, wrapped in a Box, whose filtered children are to be enumerated and transformed.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed and filtered child nodes of the current node.</returns>
+    public static IEnumerable<TResult> EnumerateChildrenBfs<TSelf, TResult, TFilter, TSelector>(this TSelf item)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TFilter : struct, IFilter<Box<TSelf>>
+        where TSelector : struct, ISelector<Box<TSelf>, TResult>
+    {
+        // Return the current item's immediate children first.
+        foreach (var child in item.Children)
+            if (TFilter.Match(child))
+                yield return TSelector.Select(child);
+
+        // Then return the children of those children.
+        foreach (var child in item.Children)
+        foreach (var grandChild in child.Item.EnumerateChildrenBfs<TSelf, TResult, TFilter, TSelector>())
+            yield return grandChild;
+    }
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a depth-first manner that satisfy a given filter,
+    ///     transforming each filtered child node using the provided selector.
+    /// </summary>
+    /// <param name="item">The node, wrapped in a Box, whose filtered children are to be enumerated and transformed.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed and filtered child nodes of the current node.</returns>
+    public static IEnumerable<TResult> EnumerateChildrenDfs<TSelf, TResult, TFilter, TSelector>(this Box<TSelf> item)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TFilter : struct, IFilter<Box<TSelf>>
+        where TSelector : struct, ISelector<Box<TSelf>, TResult>
+        => item.Item.EnumerateChildrenDfs<TSelf, TResult, TFilter, TSelector>();
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a depth-first manner that satisfy a given filter,
+    ///     transforming each filtered child node using the provided selector.
+    /// </summary>
+    /// <param name="item">The node, wrapped in a Box, whose filtered children are to be enumerated and transformed.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed and filtered child nodes of the current node.</returns>
+    public static IEnumerable<TResult> EnumerateChildrenDfs<TSelf, TResult, TFilter, TSelector>(this TSelf item)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TFilter : struct, IFilter<Box<TSelf>>
+        where TSelector : struct, ISelector<Box<TSelf>, TResult>
+    {
+        foreach (var child in item.Children)
+        {
+            if (TFilter.Match(child))
+                yield return TSelector.Select(child);
+
+            foreach (var grandChild in child.Item.EnumerateChildrenDfs<TSelf, TResult, TFilter, TSelector>())
+                yield return grandChild;
+        }
+    }
+
+    /// <summary>
     ///     Counts the number of children that match the given filter under this node.
     /// </summary>
     /// <param name="item">The node whose children are to be counted.</param>

--- a/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildren.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildren.cs
@@ -202,6 +202,63 @@ public static class IHaveBoxedChildrenExtensions
     }
 
     /// <summary>
+    ///     Recursively returns all the child items of this node selected by the given selector.
+    /// </summary>
+    /// <param name="item">The boxed node whose child items to obtain.</param>
+    /// <param name="selector">The selector to determine which child items to return.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An array of all the selected child items of this node.</returns>
+    [ExcludeFromCodeCoverage]
+    public static TResult[] GetChildItems<TSelf, TResult, TSelector>(this Box<TSelf> item, TSelector selector)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TSelector : struct, ISelector<TSelf, TResult>
+        => item.Item.GetChildItems<TSelf, TResult, TSelector>(selector);
+
+    /// <summary>
+    ///     Recursively returns all the child items of this node selected by the given selector.
+    /// </summary>
+    /// <param name="item">The node whose child items to obtain.</param>
+    /// <param name="selector">The selector to determine which child items to return.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An array of all the selected child items of this node.</returns>
+    public static TResult[] GetChildItems<TSelf, TResult, TSelector>(this TSelf item, TSelector selector)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TSelector : struct, ISelector<TSelf, TResult>
+    {
+        var totalValues = item.CountChildren(); // Ensure this method counts all descendants.
+        var results = GC.AllocateUninitializedArray<TResult>(totalValues);
+        var index = 0;
+        GetChildItemsUnsafe<TSelf, TResult, TSelector>(item, selector, results, ref index);
+        return results;
+    }
+
+    /// <summary>
+    ///     Helper method to populate child items recursively.
+    /// </summary>
+    /// <param name="item">The current node.</param>
+    /// <param name="selector">The selector to determine which child items to return.</param>
+    /// <param name="buffer">
+    ///     The span to fill with child items.
+    ///     Should be at least as big as <see cref="IHaveBoxedChildrenExtensions.CountChildren{TSelf}(Box{TSelf})"/>
+    /// </param>
+    /// <param name="index">The current index in the array.</param>
+    public static void GetChildItemsUnsafe<TSelf, TResult, TSelector>(this TSelf item, TSelector selector, Span<TResult> buffer, ref int index)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TSelector : struct, ISelector<TSelf, TResult>
+    {
+        // Populate breadth first. Improved cache locality helps here.
+        foreach (var child in item.Children)
+            buffer.DangerousGetReferenceAt(index++) = selector.Select(child.Item);
+
+        foreach (var child in item.Children)
+            GetChildItemsUnsafe(child.Item, selector, buffer, ref index);
+    }
+
+    /// <summary>
     ///     Recursively returns all the children of this node.
     /// </summary>
     /// <param name="item">The node whose children to obtain.</param>

--- a/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildren.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildren.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using NexusMods.Paths.Trees.Traits.Interfaces;
 using Reloaded.Memory.Extensions;
 
 namespace NexusMods.Paths.Trees.Traits;
@@ -90,6 +91,79 @@ public static class IHaveBoxedChildrenExtensions
         {
             yield return child;
             foreach (var grandChild in child.Item.EnumerateChildrenDfs())
+                yield return grandChild;
+        }
+    }
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a breadth-first manner that satisfy a given filter.
+    /// </summary>
+    /// <param name="item">The node, wrapped in a Box, whose children are to be enumerated.</param>
+    /// <param name="filter">The filter struct to be applied to each child node.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredBfs<TSelf, TFilter>(this Box<TSelf> item, TFilter filter)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TFilter : struct, IFilter<Box<TSelf>>
+        => item.Item.EnumerateChildrenFilteredBfs(filter);
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a breadth-first manner that satisfy a given filter.
+    /// </summary>
+    /// <param name="item">The node whose children are to be enumerated.</param>
+    /// <param name="filter">The filter struct to be applied to each child node.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
+    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredBfs<TSelf, TFilter>(this TSelf item, TFilter filter)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TFilter : struct, IFilter<Box<TSelf>>
+    {
+        // Return the current item's immediate children first if they match the filter.
+        foreach (var child in item.Children)
+            if (filter.Match(child))
+                yield return child;
+
+        // Then return the filtered children of those children.
+        foreach (var child in item.Children)
+        foreach (var grandChild in child.Item.EnumerateChildrenFilteredBfs(filter))
+            yield return grandChild;
+    }
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a depth-first manner that satisfy a given filter.
+    /// </summary>
+    /// <param name="item">The node, wrapped in a Box, whose children are to be enumerated.</param>
+    /// <param name="filter">The filter struct to be applied to each child node.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredDfs<TSelf, TFilter>(this Box<TSelf> item, TFilter filter)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TFilter : struct, IFilter<Box<TSelf>>
+        => item.Item.EnumerateChildrenFilteredDfs(filter);
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a depth-first manner that satisfy a given filter.
+    /// </summary>
+    /// <param name="item">The node whose children are to be enumerated.</param>
+    /// <param name="filter">The filter struct to be applied to each child node.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
+    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredDfs<TSelf, TFilter>(this TSelf item, TFilter filter)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TFilter : struct, IFilter<Box<TSelf>>
+    {
+        foreach (var child in item.Children)
+        {
+            if (filter.Match(child))
+                yield return child;
+
+            foreach (var grandChild in child.Item.EnumerateChildrenFilteredDfs(filter))
                 yield return grandChild;
         }
     }

--- a/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildren.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildren.cs
@@ -169,6 +169,52 @@ public static class IHaveBoxedChildrenExtensions
     }
 
     /// <summary>
+    ///     Counts the number of children that match the given filter under this node.
+    /// </summary>
+    /// <param name="item">The node whose children are to be counted.</param>
+    /// <param name="filter">The filter to apply to each child.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter.</typeparam>
+    /// <returns>The total count of children that match the filter under this node.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [ExcludeFromCodeCoverage]
+    public static int CountChildren<TSelf, TFilter>(this Box<TSelf> item, TFilter filter)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TFilter : struct, IFilter<TSelf>
+        => item.Item.CountChildren(filter);
+
+    /// <summary>
+    ///     Counts the number of children that match the given filter under this node.
+    /// </summary>
+    /// <param name="item">The node whose children are to be counted.</param>
+    /// <param name="filter">The filter to apply to each child.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter.</typeparam>
+    /// <returns>The total count of children that match the filter under this node.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int CountChildren<TSelf, TFilter>(this TSelf item, TFilter filter)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TFilter : struct, IFilter<TSelf>
+    {
+        var result = 0;
+        item.CountChildrenRecursive(ref result, filter);
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void CountChildrenRecursive<TSelf, TFilter>(this TSelf item, ref int accumulator, TFilter filter)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>
+        where TFilter : struct, IFilter<TSelf>
+    {
+        foreach (var child in item.Children)
+        {
+            var matchesFilter = filter.Match(child.Item);
+            accumulator += Unsafe.As<bool, byte>(ref matchesFilter); // Branchless increment.
+            child.Item.CountChildrenRecursive(ref accumulator, filter);
+        }
+    }
+
+    /// <summary>
     ///     Counts the number of direct child nodes of the current node.
     /// </summary>
     /// <param name="item">The node whose children are to be counted.</param>

--- a/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildrenWithKey.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildrenWithKey.cs
@@ -50,6 +50,56 @@ public static class IHaveBoxedChildrenWithKeyExtensions
         => item.Children.Count == 0;
 
     /// <summary>
+    ///     Counts the number of children that match the given filter under this node.
+    /// </summary>
+    /// <param name="item">The node whose children are to be counted.</param>
+    /// <param name="filter">The filter to apply to each child.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter.</typeparam>
+    /// <returns>The total count of children that match the filter under this node.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int CountChildren<TSelf, TKey, TFilter>(this KeyedBox<TKey, TSelf> item, TFilter filter)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>
+        where TKey : notnull
+        where TFilter : struct, IFilter<TSelf>
+        => item.Item.CountChildren<TSelf, TKey, TFilter>(filter);
+
+    /// <summary>
+    ///     Counts the number of children that match the given filter under this node.
+    /// </summary>
+    /// <param name="item">The node whose children are to be counted.</param>
+    /// <param name="filter">The filter to apply to each child.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter.</typeparam>
+    /// <returns>The total count of children that match the filter under this node.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int CountChildren<TSelf, TKey, TFilter>(this TSelf item, TFilter filter)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>
+        where TKey : notnull
+        where TFilter : struct, IFilter<TSelf>
+    {
+        var result = 0;
+        item.CountChildrenRecursive<TSelf, TKey, TFilter>(ref result, filter);
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void CountChildrenRecursive<TSelf, TKey, TFilter>(this TSelf item, ref int accumulator, TFilter filter)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>
+        where TKey : notnull
+        where TFilter : struct, IFilter<TSelf>
+    {
+        foreach (var child in item.Children)
+        {
+            var matchesFilter = filter.Match(child.Value.Item);
+            accumulator += Unsafe.As<bool, byte>(ref matchesFilter); // Branchless increment.
+            child.Value.Item.CountChildrenRecursive<TSelf, TKey, TFilter>(ref accumulator, filter);
+        }
+    }
+
+    /// <summary>
     ///     Enumerates all child nodes of the current node in a depth-first manner.
     /// </summary>
     /// <param name="item">The node whose children are to be enumerated.</param>

--- a/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildrenWithKey.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildrenWithKey.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using NexusMods.Paths.Trees.Traits.Interfaces;
 using Reloaded.Memory.Extensions;
 
 namespace NexusMods.Paths.Trees.Traits;
@@ -116,6 +117,91 @@ public static class IHaveBoxedChildrenWithKeyExtensions
         foreach (var child in item.Children)
         foreach (var grandChild in child.Value.Item.EnumerateChildrenBfs<TSelf, TKey>())
             yield return grandChild;
+    }
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a breadth-first manner that satisfy a given filter.
+    /// </summary>
+    /// <param name="item">The node, wrapped in a KeyedBox, whose children are to be enumerated.</param>
+    /// <param name="filter">The filter struct to be applied to each child node.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static IEnumerable<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>> EnumerateChildrenFilteredBfs<TSelf, TKey, TFilter>(
+        this KeyedBox<TKey, TSelf> item, TFilter filter)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>
+        where TKey : notnull
+        where TFilter : struct, IFilter<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>>
+        => item.Item.EnumerateChildrenFilteredBfs<TSelf, TKey, TFilter>(filter);
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a breadth-first manner that satisfy a given filter.
+    /// </summary>
+    /// <param name="item">The node whose children are to be enumerated.</param>
+    /// <param name="filter">The filter struct to be applied to each child node.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
+    public static IEnumerable<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>> EnumerateChildrenFilteredBfs<TSelf, TKey, TFilter>(
+        this TSelf item, TFilter filter)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>
+        where TKey : notnull
+        where TFilter : struct, IFilter<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>>
+    {
+        // Return the current item's immediate children first.
+        foreach (var child in item.Children)
+            if (filter.Match(child))
+                yield return child;
+
+        // Then return the children of those children.
+        foreach (var child in item.Children)
+        foreach (var grandChild in child.Value.Item.EnumerateChildrenFilteredBfs<TSelf, TKey, TFilter>(filter))
+            yield return grandChild;
+    }
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a depth-first manner that satisfy a given filter.
+    /// </summary>
+    /// <param name="item">The node, wrapped in a KeyedBox, whose children are to be enumerated.</param>
+    /// <param name="filter">The filter struct to be applied to each child node.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static IEnumerable<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>> EnumerateChildrenFilteredDfs<TSelf, TKey, TFilter>(
+        this KeyedBox<TKey, TSelf> item, TFilter filter)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>
+        where TKey : notnull
+        where TFilter : struct, IFilter<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>>
+        => item.Item.EnumerateChildrenFilteredDfs<TSelf, TKey, TFilter>(filter);
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a depth-first manner that satisfy a given filter.
+    /// </summary>
+    /// <param name="item">The node whose children are to be enumerated.</param>
+    /// <param name="filter">The filter struct to be applied to each child node.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
+    public static IEnumerable<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>> EnumerateChildrenFilteredDfs<TSelf, TKey, TFilter>(
+        this TSelf item, TFilter filter)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>
+        where TKey : notnull
+        where TFilter : struct, IFilter<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>>
+    {
+        foreach (var child in item.Children)
+        {
+            if (filter.Match(child))
+                yield return child;
+
+            foreach (var grandChild in child.Value.Item.EnumerateChildrenFilteredDfs<TSelf, TKey, TFilter>(filter))
+                yield return grandChild;
+        }
     }
 
     /// <summary>

--- a/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildrenWithKey.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildrenWithKey.cs
@@ -127,9 +127,7 @@ public static class IHaveBoxedChildrenWithKeyExtensions
         {
             yield return child;
             foreach (var grandChild in child.Value.Item.EnumerateChildrenDfs<TSelf, TKey>())
-            {
                 yield return grandChild;
-            }
         }
     }
 
@@ -213,14 +211,13 @@ public static class IHaveBoxedChildrenWithKeyExtensions
     ///     Enumerates all child nodes of the current node in a depth-first manner that satisfy a given filter.
     /// </summary>
     /// <param name="item">The node, wrapped in a KeyedBox, whose children are to be enumerated.</param>
-    /// <param name="filter">The filter struct to be applied to each child node.</param>
     /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
     /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
     [ExcludeFromCodeCoverage] // Wrapper
     public static IEnumerable<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>> EnumerateChildrenDfs<TSelf, TKey, TFilter>(
-        this KeyedBox<TKey, TSelf> item, TFilter filter)
+        this KeyedBox<TKey, TSelf> item)
         where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>
         where TKey : notnull
         where TFilter : struct, IFilter<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>>
@@ -246,6 +243,179 @@ public static class IHaveBoxedChildrenWithKeyExtensions
                 yield return child;
 
             foreach (var grandChild in child.Value.Item.EnumerateChildrenDfs<TSelf, TKey, TFilter>())
+                yield return grandChild;
+        }
+    }
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a breadth-first manner, transforming each child node using the provided selector.
+    /// </summary>
+    /// <param name="item">The node whose children are to be enumerated and transformed.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed child nodes of the current node.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static IEnumerable<TResult> EnumerateChildrenBfs<TSelf, TKey, TResult, TSelector>(this KeyedBox<TKey, TSelf> item)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>
+        where TKey : notnull
+        where TSelector : struct, ISelector<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>, TResult>
+        => item.Item.EnumerateChildrenBfs<TSelf, TKey, TResult, TSelector>();
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a breadth-first manner, transforming each child node using the provided selector.
+    /// </summary>
+    /// <param name="item">The node whose children are to be enumerated and transformed.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed child nodes of the current node.</returns>
+    public static IEnumerable<TResult> EnumerateChildrenBfs<TSelf, TKey, TResult, TSelector>(this TSelf item)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>
+        where TKey : notnull
+        where TSelector : struct, ISelector<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>, TResult>
+    {
+        // Return the current item's immediate children first.
+        foreach (var child in item.Children)
+            yield return TSelector.Select(child);
+
+        // Then return the transformed children of those children.
+        foreach (var child in item.Children)
+        foreach (var grandChild in child.Value.Item.EnumerateChildrenBfs<TSelf, TKey, TResult, TSelector>())
+            yield return grandChild;
+    }
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a depth-first manner, transforming each child node using
+    ///     the provided selector.
+    /// </summary>
+    /// <param name="item">The node whose children are to be enumerated and transformed.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed child nodes of the current node.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static IEnumerable<TResult> EnumerateChildrenDfs<TSelf, TKey, TResult, TSelector>(
+        this KeyedBox<TKey, TSelf> item)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>
+        where TKey : notnull
+        where TSelector : struct, ISelector<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>, TResult>
+        => item.Item.EnumerateChildrenDfs<TSelf, TKey, TResult, TSelector>();
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a depth-first manner, transforming each child node using
+    ///     the provided selector.
+    /// </summary>
+    /// <param name="item">The node whose children are to be enumerated and transformed.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed child nodes of the current node.</returns>
+    public static IEnumerable<TResult> EnumerateChildrenDfs<TSelf, TKey, TResult, TSelector>(this TSelf item)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>
+        where TKey : notnull
+        where TSelector : struct, ISelector<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>, TResult>
+    {
+        foreach (var child in item.Children)
+        {
+            yield return TSelector.Select(child);
+            foreach (var grandChild in child.Value.Item.EnumerateChildrenDfs<TSelf, TKey, TResult, TSelector>())
+                yield return grandChild;
+        }
+    }
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a breadth-first manner that satisfy a given filter,
+    ///     transforming each filtered child node using the provided selector.
+    /// </summary>
+    /// <param name="item">The node whose filtered children are to be enumerated and transformed.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed and filtered child nodes of the current node.</returns>
+    public static IEnumerable<TResult> EnumerateChildrenBfs<TSelf, TKey, TResult, TFilter, TSelector>(this KeyedBox<TKey, TSelf> item)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>
+        where TKey : notnull
+        where TFilter : struct, IFilter<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>>
+        where TSelector : struct, ISelector<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>, TResult>
+        => item.Item.EnumerateChildrenBfs<TSelf, TKey, TResult, TFilter, TSelector>();
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a breadth-first manner that satisfy a given filter,
+    ///     transforming each filtered child node using the provided selector.
+    /// </summary>
+    /// <param name="item">The node whose filtered children are to be enumerated and transformed.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed and filtered child nodes of the current node.</returns>
+    public static IEnumerable<TResult> EnumerateChildrenBfs<TSelf, TKey, TResult, TFilter, TSelector>(this TSelf item)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>
+        where TKey : notnull
+        where TFilter : struct, IFilter<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>>
+        where TSelector : struct, ISelector<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>, TResult>
+    {
+        // Return the current item's immediate children first if they match the filter.
+        foreach (var child in item.Children)
+            if (TFilter.Match(child))
+                yield return TSelector.Select(child);
+
+        // Then return the transformed and filtered children of those children.
+        foreach (var child in item.Children)
+        foreach (var grandChild in child.Value.Item.EnumerateChildrenBfs<TSelf, TKey, TResult, TFilter, TSelector>())
+            yield return grandChild;
+    }
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a depth-first manner that satisfy a given filter,
+    ///     transforming each filtered child node using the provided selector.
+    /// </summary>
+    /// <param name="item">The node whose filtered children are to be enumerated and transformed.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed and filtered child nodes of the current node.</returns>
+    public static IEnumerable<TResult> EnumerateChildrenDfs<TSelf, TKey, TResult, TFilter, TSelector>(
+        this KeyedBox<TKey, TSelf> item)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>
+        where TKey : notnull
+        where TFilter : struct, IFilter<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>>
+        where TSelector : struct, ISelector<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>, TResult>
+        => item.Item.EnumerateChildrenDfs<TSelf, TKey, TResult, TFilter, TSelector>();
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a depth-first manner that satisfy a given filter,
+    ///     transforming each filtered child node using the provided selector.
+    /// </summary>
+    /// <param name="item">The node whose filtered children are to be enumerated and transformed.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed and filtered child nodes of the current node.</returns>
+    public static IEnumerable<TResult> EnumerateChildrenDfs<TSelf, TKey, TResult, TFilter, TSelector>(this TSelf item)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>
+        where TKey : notnull
+        where TFilter : struct, IFilter<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>>
+        where TSelector : struct, ISelector<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>, TResult>
+    {
+        foreach (var child in item.Children)
+        {
+            if (TFilter.Match(child))
+                yield return TSelector.Select(child);
+
+            foreach (var grandChild in child.Value.Item.EnumerateChildrenDfs<TSelf, TKey, TResult, TFilter, TSelector>())
                 yield return grandChild;
         }
     }

--- a/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildrenWithKey.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildrenWithKey.cs
@@ -826,4 +826,17 @@ public static class IHaveBoxedChildrenWithKeyExtensions
         where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>
         where TKey : notnull
         => item.Item.Children;
+
+    /// <summary>
+    ///     Retrieves the dictionary containing all the keyed children of the current node.
+    /// </summary>
+    /// <param name="item">The keyed box containing the node whose children are to be retrieved.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of the child node.</typeparam>
+    /// <returns>A dictionary of the children keyed by TKey.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static Dictionary<TKey, KeyedBox<TKey, TSelf>> Children<TSelf, TKey>(this KeyValuePair<TKey, KeyedBox<TKey, TSelf>> item)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>
+        where TKey : notnull
+        => item.Value.Item.Children;
 }

--- a/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildrenWithKey.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveBoxedChildrenWithKey.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Reloaded.Memory.Extensions;
 
@@ -48,7 +49,7 @@ public static class IHaveBoxedChildrenWithKeyExtensions
         => item.Children.Count == 0;
 
     /// <summary>
-    /// Enumerates all child nodes of the current node in a depth-first manner.
+    ///     Enumerates all child nodes of the current node in a depth-first manner.
     /// </summary>
     /// <param name="item">The node whose children are to be enumerated.</param>
     /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
@@ -61,7 +62,7 @@ public static class IHaveBoxedChildrenWithKeyExtensions
         => item.Item.EnumerateChildrenDfs<TSelf, TKey>();
 
     /// <summary>
-    /// Enumerates all child nodes of the current node in a depth-first manner.
+    ///     Enumerates all child nodes of the current node in a depth-first manner.
     /// </summary>
     /// <param name="item">The node whose children are to be enumerated.</param>
     /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
@@ -83,7 +84,7 @@ public static class IHaveBoxedChildrenWithKeyExtensions
     }
 
     /// <summary>
-    /// Enumerates all child nodes of the current node in a breadth-first manner.
+    ///     Enumerates all child nodes of the current node in a breadth-first manner.
     /// </summary>
     /// <param name="item">The node whose children are to be enumerated.</param>
     /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
@@ -96,7 +97,7 @@ public static class IHaveBoxedChildrenWithKeyExtensions
         => item.Item.EnumerateChildrenBfs<TSelf, TKey>();
 
     /// <summary>
-    /// Enumerates all child nodes of the current node in a breadth-first manner.
+    ///     Enumerates all child nodes of the current node in a breadth-first manner.
     /// </summary>
     /// <param name="item">The node whose children are to be enumerated.</param>
     /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
@@ -300,4 +301,17 @@ public static class IHaveBoxedChildrenWithKeyExtensions
                 GetLeavesUnsafe(pair.Value.Item, leavesSpan, ref index);
         }
     }
+
+    /// <summary>
+    ///     Retrieves the dictionary containing all the keyed children of the current node.
+    /// </summary>
+    /// <param name="item">The keyed box containing the node whose children are to be retrieved.</param>
+    /// <typeparam name="TKey">The type of key used to identify children.</typeparam>
+    /// <typeparam name="TSelf">The type of the child node.</typeparam>
+    /// <returns>A dictionary of the children keyed by TKey.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static Dictionary<TKey, KeyedBox<TKey, TSelf>> Children<TSelf, TKey>(this KeyedBox<TKey, TSelf> item)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>
+        where TKey : notnull
+        => item.Item.Children;
 }

--- a/src/NexusMods.Paths/Trees/Traits/IHaveDepthInformation.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveDepthInformation.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace NexusMods.Paths.Trees.Traits;
@@ -39,4 +40,14 @@ public static class IHaveDepthInformationExtensions
         where TSelf : struct, IHaveDepthInformation
         where TKey : notnull
         => item.Item.Depth;
+
+    /// <summary>
+    ///     Retrieves the depth of the node in the tree structure.
+    /// </summary>
+    /// <param name="item">The keyed boxed node whose depth is to be retrieved.</param>
+    /// <returns>The depth of the node.</returns>
+    public static ushort Depth<TSelf, TKey>(this KeyValuePair<TKey, KeyedBox<TKey, TSelf>> item)
+        where TSelf : struct, IHaveDepthInformation
+        where TKey : notnull
+        => item.Value.Item.Depth;
 }

--- a/src/NexusMods.Paths/Trees/Traits/IHaveDepthInformation.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveDepthInformation.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace NexusMods.Paths.Trees.Traits;
 
 /// <summary>
@@ -10,4 +12,31 @@ public interface IHaveDepthInformation
     ///     So, in a FileTree `bar` in `/foo/bar/baz` will have a depth of 2 due to the `/` having a depth of 0.
     /// </summary>
     public ushort Depth { get; }
+}
+
+/// <summary>
+///     Trait methods for <see cref="IHaveObservableChildren{TSelf}" />.
+/// </summary>
+[ExcludeFromCodeCoverage] // Wrapper
+// ReSharper disable once InconsistentNaming
+public static class IHaveDepthInformationExtensions
+{
+    /// <summary>
+    ///     Retrieves the depth of the node in the tree structure.
+    /// </summary>
+    /// <param name="item">The boxed node whose depth is to be retrieved.</param>
+    /// <returns>The depth of the node.</returns>
+    public static ushort Depth<TSelf>(this Box<TSelf> item)
+        where TSelf : struct, IHaveDepthInformation
+        => item.Item.Depth;
+
+    /// <summary>
+    ///     Retrieves the depth of the node in the tree structure.
+    /// </summary>
+    /// <param name="item">The keyed boxed node whose depth is to be retrieved.</param>
+    /// <returns>The depth of the node.</returns>
+    public static ushort Depth<TSelf, TKey>(this KeyedBox<TKey, TSelf> item)
+        where TSelf : struct, IHaveDepthInformation
+        where TKey : notnull
+        => item.Item.Depth;
 }

--- a/src/NexusMods.Paths/Trees/Traits/IHaveKey.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveKey.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using NexusMods.Paths.Trees.Traits.Interfaces;
 using Reloaded.Memory.Extensions;
 
@@ -97,7 +96,7 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildren
     /// <returns>An array of all the keys of the children of this node.</returns>
     public static TKey[] GetKeys<TSelf, TKey>(this Box<TSelf> item)
         where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveKey<TKey> =>
-        item.Item.GetChildItems<TSelf, TKey, KeySelector<TSelf, TKey>>(new KeySelector<TSelf, TKey>());
+        item.Item.GetChildrenRecursive<TSelf, TKey, KeySelector<TSelf, TKey>>();
 
     /// <summary>
     ///     Recursively returns all the keys of the children of this node.
@@ -106,10 +105,10 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildren
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
     /// <returns>An array of all the keys of the children of this node.</returns>
-    [ExcludeFromCodeCoverage]
+    [ExcludeFromCodeCoverage] // Wrapper
     public static TKey[] GetKeys<TSelf, TKey>(this TSelf item)
         where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveKey<TKey> =>
-        item.GetChildItems<TSelf, TKey, KeySelector<TSelf, TKey>>(new KeySelector<TSelf, TKey>());
+        item.GetChildrenRecursive<TSelf, TKey, KeySelector<TSelf, TKey>>();
 
     /// <summary>
     ///     Helper method to populate keys recursively.
@@ -123,7 +122,7 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildren
     [ExcludeFromCodeCoverage]
     public static void GetKeysUnsafe<TSelf, TKey>(TSelf item, Span<TKey> buffer, ref int index)
         where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveKey<TKey> =>
-        item.GetChildItemsUnsafe(new KeySelector<TSelf, TKey>(), buffer, ref index);
+        item.GetChildrenRecursiveUnsafe<TSelf, TKey, KeySelector<TSelf, TKey>>(buffer, ref index);
 
     /// <summary>
     ///     Finds a node in the tree based on a given sequence of keys, starting the search from the root node.
@@ -511,7 +510,7 @@ public static class IHaveKeyExtensionsForIHaveObservableChildren
     /// <returns>An array of all the keys of the children of this node.</returns>
     public static TKey[] GetKeys<TSelf, TKey>(this Box<TSelf> item)
         where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveKey<TKey> =>
-        item.Item.GetChildItems<TSelf, TKey, KeySelector<TSelf, TKey>>(new KeySelector<TSelf, TKey>());
+        item.Item.GetChildrenRecursive<TSelf, TKey, KeySelector<TSelf, TKey>>();
 
     /// <summary>
     ///     Recursively returns all the keys of the children of this node.
@@ -523,7 +522,7 @@ public static class IHaveKeyExtensionsForIHaveObservableChildren
     [ExcludeFromCodeCoverage]
     public static TKey[] GetKeys<TSelf, TKey>(this TSelf item)
         where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveKey<TKey> =>
-        item.GetChildItems<TSelf, TKey, KeySelector<TSelf, TKey>>(new KeySelector<TSelf, TKey>());
+        item.GetChildrenRecursive<TSelf, TKey, KeySelector<TSelf, TKey>>();
 
     /// <summary>
     ///     Helper method to populate keys recursively.
@@ -537,7 +536,7 @@ public static class IHaveKeyExtensionsForIHaveObservableChildren
     [ExcludeFromCodeCoverage]
     public static void GetKeysUnsafe<TSelf, TKey>(TSelf item, Span<TKey> buffer, ref int index)
         where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveKey<TKey> =>
-        item.GetChildItemsUnsafe(new KeySelector<TSelf, TKey>(), buffer, ref index);
+        item.GetChildrenRecursiveUnsafe<TSelf, TKey, KeySelector<TSelf, TKey>>(buffer, ref index);
 
     /// <summary>
     ///     Finds a node in the tree based on a given sequence of keys, starting the search from the root node.
@@ -927,7 +926,7 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildrenWithKey
     public static TKey[] GetKeys<TKey, TSelf>(this KeyedBox<TKey, TSelf> item)
         where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveKey<TKey>
         where TKey : struct =>
-        item.GetChildItems<TKey, TSelf, TKey, KeySelector<TSelf, TKey>>(new KeySelector<TSelf, TKey>());
+        item.GetChildrenRecursive<TSelf, TKey, TKey, KeySelector<TSelf, TKey>>();
 
     /// <summary>
     ///     Recursively returns all the keys of the children of this node.
@@ -940,7 +939,7 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildrenWithKey
     public static TKey[] GetKeys<TKey, TSelf>(this TSelf item)
         where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveKey<TKey>
         where TKey : struct =>
-        item.GetChildItems<TKey, TSelf, TKey, KeySelector<TSelf, TKey>>(new KeySelector<TSelf, TKey>());
+        item.GetChildrenRecursive<TSelf, TKey, TKey, KeySelector<TSelf, TKey>>();
 
     /// <summary>
     ///     Helper method to populate keys recursively.
@@ -955,7 +954,7 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildrenWithKey
     public static void GetKeysUnsafe<TKey, TSelf>(TSelf item, Span<TKey> buffer, ref int index)
         where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveKey<TKey>
         where TKey : struct, IHaveKey<TSelf> =>
-        item.GetChildItemsUnsafe<TKey, TSelf, TKey, KeySelector<TSelf, TKey>>(new KeySelector<TSelf, TKey>(), buffer, ref index);
+        item.GetChildrenRecursiveUnsafe<TSelf, TKey, TKey, KeySelector<TSelf, TKey>>(buffer, ref index);
 
     /// <summary>
     ///     Finds a node in the tree based on a given relative path of keys, starting the search from the root node.
@@ -1286,5 +1285,5 @@ public static class IHaveKeyExtensions
 internal struct KeySelector<TSelf, TKey> : ISelector<TSelf, TKey>
     where TSelf : struct, IHaveKey<TKey>
 {
-    public TKey Select(TSelf item) => item.Key;
+    public static TKey Select(TSelf item) => item.Key;
 }

--- a/src/NexusMods.Paths/Trees/Traits/IHaveKey.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveKey.cs
@@ -334,6 +334,10 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildren
     ///     A list of nodes where each node's path to the root (root being node at any depth)
     ///     matches the specified sequence of keys.
     /// </returns>
+    /// <remarks>
+    ///     This is same as <see cref="FindSubPathRootsByKeyUpward{TSelf,TKey}(NexusMods.Paths.Trees.Box{TSelf},System.Span{TKey})"/>
+    ///     but returns the node from the other end. (Returns the leaves instead of the root)
+    /// </remarks>
     public static List<Box<TSelf>> FindSubPathsByKeyUpward<TSelf, TKey>(this Box<TSelf> root, Span<TKey> keys)
         where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveKey<TKey>, IHaveParent<TSelf>
         where TKey : notnull
@@ -354,6 +358,10 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildren
     ///     A list of nodes where each node's path to the root (root being node at any depth)
     ///     matches the specified sequence of keys.
     /// </returns>
+    /// <remarks>
+    ///     This is same as <see cref="FindSubPathRootsByKeyUpward{TSelf,TKey}(NexusMods.Paths.Trees.Box{TSelf},System.Span{TKey})"/>
+    ///     but returns the node from the other end. (Returns the leaves instead of the root)
+    /// </remarks>
     [ExcludeFromCodeCoverage]
     [Obsolete("This method causes temporary boxing of object. Do not use unless you have no other way to access this item. Use this method via Box<TSelf> instead.")]
     public static List<Box<TSelf>> FindSubPathsByKeyUpward<TSelf, TKey>(this TSelf root, Span<TKey> keys)
@@ -372,6 +380,67 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildren
 
         foreach (var child in node.Item.Children)
             FindSubPathsByKeyUpward(child, keys, foundNodes);
+    }
+
+    /// <summary>
+    ///     Searches for all nodes within a tree whose children match a specified sequence of keys.
+    ///     (Optimized <see cref="FindSubPathsByKeyFromRoot{TSelf,TKey}(NexusMods.Paths.Trees.Box{TSelf},System.Span{TKey})"/>)
+    /// </summary>
+    /// <param name="node">The root node of the tree, wrapped in a ChildBox.</param>
+    /// <param name="keys">The sequence of keys to be matched, starting from the leaf node and moving upwards.</param>
+    /// <typeparam name="TSelf">The type of the node in the tree.</typeparam>
+    /// <typeparam name="TKey">The type of the key used in the tree.</typeparam>
+    /// <returns>
+    ///     A list of roots where each root's path to the node matches the specified sequence of keys.
+    /// </returns>
+    /// <remarks>
+    ///     This is same as <see cref="FindSubPathsByKeyUpward{TSelf,TKey}(NexusMods.Paths.Trees.Box{TSelf},System.Span{TKey})"/>
+    ///     but returns the node from the other end. (Returns the root instead of the leaf)
+    /// </remarks>
+    public static List<Box<TSelf>> FindSubPathRootsByKeyUpward<TSelf, TKey>(this Box<TSelf> node, Span<TKey> keys)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveKey<TKey>, IHaveParent<TSelf>
+        where TKey : notnull
+    {
+        var foundNodes = new List<Box<TSelf>>();
+        FindSubPathRootsByKeyUpward(node, keys, foundNodes);
+        return foundNodes;
+    }
+
+    /// <summary>
+    ///     Searches for all nodes within a tree whose children match a specified sequence of keys.
+    ///     (Optimized <see cref="FindSubPathsByKeyFromRoot{TSelf,TKey}(NexusMods.Paths.Trees.Box{TSelf},System.Span{TKey})"/>)
+    /// </summary>
+    /// <param name="node">The starting node for the search.</param>
+    /// <param name="keys">The sequence of keys to be matched, starting from each descendant node and moving upwards.</param>
+    /// <typeparam name="TSelf">The type of the node in the tree.</typeparam>
+    /// <typeparam name="TKey">The type of the key used in the tree.</typeparam>
+    /// <returns>
+    ///     A list of nodes where each node's path to the root (root being node at any depth)
+    ///     matches the specified sequence of keys.
+    /// </returns>
+    /// <remarks>
+    ///     This is same as <see cref="FindSubPathsByKeyUpward{TSelf,TKey}(NexusMods.Paths.Trees.Box{TSelf},System.Span{TKey})"/>
+    ///     but returns the node from the other end. (Returns the root instead of the leaf)
+    /// </remarks>
+    [ExcludeFromCodeCoverage]
+    [Obsolete("This method causes temporary boxing of object. Do not use unless you have no other way to access this item. Use this method via Box<TSelf> instead.")]
+    public static List<Box<TSelf>> FindSubPathRootsByKeyUpward<TSelf, TKey>(this TSelf node, Span<TKey> keys)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveKey<TKey>, IHaveParent<TSelf>
+        where TKey : notnull
+    {
+        return FindSubPathsByKeyUpward((Box<TSelf>)node, keys);
+    }
+
+    private static void FindSubPathRootsByKeyUpward<TSelf, TKey>(Box<TSelf> node, Span<TKey> keys, List<Box<TSelf>> foundNodes)
+        where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveKey<TKey>, IHaveParent<TSelf>
+        where TKey : notnull
+    {
+        var result = node.FindRootByKeyUpward(keys);
+        if (result != null)
+            foundNodes.Add(result);
+
+        foreach (var child in node.Item.Children)
+            FindSubPathRootsByKeyUpward(child, keys, foundNodes);
     }
 }
 
@@ -691,6 +760,10 @@ public static class IHaveKeyExtensionsForIHaveObservableChildren
     ///     A list of nodes where each node's path to the root (root being node at any depth)
     ///     matches the specified sequence of keys.
     /// </returns>
+    /// <remarks>
+    ///     This is same as <see cref="FindSubPathRootsByKeyUpward{TSelf,TKey}(NexusMods.Paths.Trees.Box{TSelf},System.Span{TKey})"/>
+    ///     but returns the node from the other end. (Returns the leaves instead of the root)
+    /// </remarks>
     public static List<Box<TSelf>> FindSubPathsByKeyUpward<TSelf, TKey>(this Box<TSelf> root, Span<TKey> keys)
         where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveKey<TKey>, IHaveParent<TSelf>
         where TKey : notnull
@@ -711,6 +784,10 @@ public static class IHaveKeyExtensionsForIHaveObservableChildren
     ///     A list of nodes where each node's path to the root (root being node at any depth)
     ///     matches the specified sequence of keys.
     /// </returns>
+    /// <remarks>
+    ///     This is same as <see cref="FindSubPathRootsByKeyUpward{TSelf,TKey}(NexusMods.Paths.Trees.Box{TSelf},System.Span{TKey})"/>
+    ///     but returns the node from the other end. (Returns the leaves instead of the root)
+    /// </remarks>
     [ExcludeFromCodeCoverage]
     [Obsolete("This method causes temporary boxing of object. Do not use unless you have no other way to access this item. Use this method via Box<TSelf> instead.")]
     public static List<Box<TSelf>> FindSubPathsByKeyUpward<TSelf, TKey>(this TSelf root, Span<TKey> keys)
@@ -727,6 +804,66 @@ public static class IHaveKeyExtensionsForIHaveObservableChildren
 
         foreach (var child in node.Item.Children)
             FindSubPathsByKeyUpward(child, keys, foundNodes);
+    }
+
+    /// <summary>
+    ///     Searches for all nodes within a tree whose children match a specified sequence of keys.
+    ///     (Optimized <see cref="FindSubPathsByKeyFromRoot{TSelf,TKey}(NexusMods.Paths.Trees.Box{TSelf},System.Span{TKey})"/>)
+    /// </summary>
+    /// <param name="root">The root node of the tree, wrapped in a ChildBox.</param>
+    /// <param name="keys">The sequence of keys to be matched, starting from the leaf node and moving upwards.</param>
+    /// <typeparam name="TSelf">The type of the node in the tree.</typeparam>
+    /// <typeparam name="TKey">The type of the key used in the tree.</typeparam>
+    /// <returns>
+    ///     A list of nodes where each node's path to the root (root being node at any depth)
+    ///     matches the specified sequence of keys.
+    /// </returns>
+    /// <remarks>
+    ///     This is same as <see cref="FindSubPathsByKeyUpward{TSelf,TKey}(NexusMods.Paths.Trees.Box{TSelf},System.Span{TKey})"/>
+    ///     but returns the node from the other end. (Returns the root instead of the leaf)
+    /// </remarks>
+    public static List<Box<TSelf>> FindSubPathRootsByKeyUpward<TSelf, TKey>(this Box<TSelf> root, Span<TKey> keys)
+        where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveKey<TKey>, IHaveParent<TSelf>
+        where TKey : notnull
+    {
+        var foundNodes = new List<Box<TSelf>>();
+        FindSubPathRootsByKeyUpward(root, keys, foundNodes);
+        return foundNodes;
+    }
+
+    /// <summary>
+    ///     Searches for all nodes within a tree whose children match a specified sequence of keys.
+    ///     (Optimized <see cref="FindSubPathsByKeyFromRoot{TSelf,TKey}(NexusMods.Paths.Trees.Box{TSelf},System.Span{TKey})"/>)
+    /// </summary>
+    /// <param name="root">The starting node for the search.</param>
+    /// <param name="keys">The sequence of keys to be matched, starting from each descendant node and moving upwards.</param>
+    /// <typeparam name="TSelf">The type of the node in the tree.</typeparam>
+    /// <typeparam name="TKey">The type of the key used in the tree.</typeparam>
+    /// <returns>
+    ///     A list of nodes where each node's path to the root (root being node at any depth)
+    ///     matches the specified sequence of keys.
+    /// </returns>
+    /// <remarks>
+    ///     This is same as <see cref="FindSubPathsByKeyUpward{TSelf,TKey}(NexusMods.Paths.Trees.Box{TSelf},System.Span{TKey})"/>
+    ///     but returns the node from the other end. (Returns the root instead of the leaf)
+    /// </remarks>
+    [ExcludeFromCodeCoverage]
+    [Obsolete("This method causes temporary boxing of object. Do not use unless you have no other way to access this item. Use this method via Box<TSelf> instead.")]
+    public static List<Box<TSelf>> FindSubPathRootsByKeyUpward<TSelf, TKey>(this TSelf root, Span<TKey> keys)
+        where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveKey<TKey>, IHaveParent<TSelf>
+        where TKey : notnull
+        => FindSubPathRootsByKeyUpward((Box<TSelf>)root, keys);
+
+    private static void FindSubPathRootsByKeyUpward<TSelf, TKey>(Box<TSelf> node, Span<TKey> keys, List<Box<TSelf>> foundNodes)
+        where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveKey<TKey>, IHaveParent<TSelf>
+        where TKey : notnull
+    {
+        var result = node.FindRootByKeyUpward(keys);
+        if (result != null)
+            foundNodes.Add(result);
+
+        foreach (var child in node.Item.Children)
+            FindSubPathRootsByKeyUpward(child, keys, foundNodes);
     }
 }
 
@@ -1042,6 +1179,10 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildrenWithKey
     ///     A list of nodes where each node's path to the root (root being node at any depth)
     ///     matches the specified sequence of keys.
     /// </returns>
+    /// <remarks>
+    ///     This is same as <see cref="FindSubPathRootsByKeyUpward{TSelf,TKey}(NexusMods.Paths.Trees.KeyedBox{TKey,TSelf},System.Span{TKey})"/>
+    ///     but returns the node from the other end. (Returns the leaves instead of the root)
+    /// </remarks>
     public static List<KeyedBox<TKey, TSelf>> FindSubPathsByKeyUpward<TSelf, TKey>(this KeyedBox<TKey, TSelf> root, Span<TKey> keys)
         where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveKey<TKey>, IHaveParent<TSelf>
         where TKey : notnull
@@ -1062,6 +1203,10 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildrenWithKey
     ///     A list of nodes where each node's path to the root (root being node at any depth)
     ///     matches the specified sequence of keys.
     /// </returns>
+    /// <remarks>
+    ///     This is same as <see cref="FindSubPathRootsByKeyUpward{TSelf,TKey}(NexusMods.Paths.Trees.KeyedBox{TKey,TSelf},System.Span{TKey})"/>
+    ///     but returns the node from the other end. (Returns the leaves instead of the root)
+    /// </remarks>
     [ExcludeFromCodeCoverage]
     [Obsolete("This method causes temporary boxing of object. Do not use unless you have no other way to access this item. Use this method via Box<TSelf> instead.")]
     public static List<KeyedBox<TKey, TSelf>> FindSubPathsByKeyUpward<TSelf, TKey>(this TSelf root, Span<TKey> keys)
@@ -1078,6 +1223,66 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildrenWithKey
 
         foreach (var child in node.Item.Children)
             FindSubPathsByKeyUpward(child.Value, keys, foundNodes);
+    }
+
+    /// <summary>
+    ///     Searches for all nodes within a tree whose children match a specified sequence of keys.
+    ///     (Optimized <see cref="FindSubPathsByKeyFromRoot{TSelf,TKey}(NexusMods.Paths.Trees.KeyedBox{TKey,TSelf},System.Span{TKey})"/>)
+    /// </summary>
+    /// <param name="root">The root node of the tree, wrapped in a ChildBox.</param>
+    /// <param name="keys">The sequence of keys to be matched, starting from the leaf node and moving upwards.</param>
+    /// <typeparam name="TSelf">The type of the node in the tree.</typeparam>
+    /// <typeparam name="TKey">The type of the key used in the tree.</typeparam>
+    /// <returns>
+    ///     A list of nodes where each node's path to the root (root being node at any depth)
+    ///     matches the specified sequence of keys.
+    /// </returns>
+    /// <remarks>
+    ///     This is same as <see cref="FindSubPathsByKeyUpward{TSelf,TKey}(NexusMods.Paths.Trees.KeyedBox{TKey,TSelf},System.Span{TKey})"/>
+    ///     but returns the node from the other end. (Returns the root instead of the leaf)
+    /// </remarks>
+    public static List<Box<TSelf>> FindSubPathRootsByKeyUpward<TSelf, TKey>(this KeyedBox<TKey, TSelf> root, Span<TKey> keys)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveKey<TKey>, IHaveParent<TSelf>
+        where TKey : notnull
+    {
+        var foundNodes = new List<Box<TSelf>>();
+        FindSubPathRootsByKeyUpward(root, keys, foundNodes);
+        return foundNodes;
+    }
+
+    /// <summary>
+    ///     Searches for all nodes within a tree whose children match a specified sequence of keys.
+    ///     (Optimized <see cref="FindSubPathsByKeyFromRoot{TSelf,TKey}(NexusMods.Paths.Trees.KeyedBox{TKey,TSelf},System.Span{TKey})t"/>)
+    /// </summary>
+    /// <param name="root">The starting node for the search.</param>
+    /// <param name="keys">The sequence of keys to be matched, starting from each descendant node and moving upwards.</param>
+    /// <typeparam name="TSelf">The type of the node in the tree.</typeparam>
+    /// <typeparam name="TKey">The type of the key used in the tree.</typeparam>
+    /// <returns>
+    ///     A list of nodes where each node's path to the root (root being node at any depth)
+    ///     matches the specified sequence of keys.
+    /// </returns>
+    /// <remarks>
+    ///     This is same as <see cref="FindSubPathsByKeyUpward{TSelf,TKey}(NexusMods.Paths.Trees.KeyedBox{TKey,TSelf},System.Span{TKey})"/>
+    ///     but returns the node from the other end. (Returns the root instead of the leaf)
+    /// </remarks>
+    [ExcludeFromCodeCoverage]
+    [Obsolete("This method causes temporary boxing of object. Do not use unless you have no other way to access this item. Use this method via Box<TSelf> instead.")]
+    public static List<Box<TSelf>> FindSubPathRootsByKeyUpward<TSelf, TKey>(this TSelf root, Span<TKey> keys)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveKey<TKey>, IHaveParent<TSelf>
+        where TKey : notnull
+        => FindSubPathRootsByKeyUpward((KeyedBox<TKey, TSelf>)root, keys);
+
+    private static void FindSubPathRootsByKeyUpward<TSelf, TKey>(KeyedBox<TKey, TSelf> node, Span<TKey> keys, List<Box<TSelf>> foundNodes)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveKey<TKey>, IHaveParent<TSelf>
+        where TKey : notnull
+    {
+        var result = node.FindRootByKeyUpward(keys);
+        if (result != null)
+            foundNodes.Add(result);
+
+        foreach (var child in node.Item.Children)
+            FindSubPathRootsByKeyUpward(child.Value, keys, foundNodes);
     }
 }
 

--- a/src/NexusMods.Paths/Trees/Traits/IHaveKey.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveKey.cs
@@ -1218,7 +1218,7 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildrenWithKey
 
     /// <summary>
     ///     Searches for all nodes within a tree whose children match a specified sequence of keys.
-    ///     (Optimized <see cref="FindSubPathsByKeyFromRoot{TSelf,TKey}(NexusMods.Paths.Trees.KeyedBox{TKey,TSelf},System.Span{TKey})t"/>)
+    ///     (Optimized <see cref="FindSubPathsByKeyFromRoot{TSelf,TKey}(NexusMods.Paths.Trees.KeyedBox{TKey,TSelf},System.Span{TKey})"/>)
     /// </summary>
     /// <param name="root">The starting node for the search.</param>
     /// <param name="keys">The sequence of keys to be matched, starting from each descendant node and moving upwards.</param>

--- a/src/NexusMods.Paths/Trees/Traits/IHaveKey.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveKey.cs
@@ -1080,3 +1080,34 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildrenWithKey
             FindSubPathsByKeyUpward(child.Value, keys, foundNodes);
     }
 }
+
+/// <summary>
+///    Extensions for <see cref="IHaveKey{TKey}"/>
+/// </summary>
+[ExcludeFromCodeCoverage] // Wrappers
+// ReSharper disable once InconsistentNaming
+public static class IHaveKeyExtensions
+{
+    /// <summary>
+    ///     Retrieves the key of the node.
+    /// </summary>
+    /// <param name="item">The keyed boxed node whose key is to be retrieved.</param>
+    /// <typeparam name="TSelf">The type of the child node.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <returns>The key of the node.</returns>
+    public static TKey Key<TSelf, TKey>(this KeyedBox<TKey, TSelf> item)
+        where TSelf : struct, IHaveKey<TKey>
+        where TKey : notnull
+        => item.Item.Key;
+
+    /// <summary>
+    ///     Retrieves the key of the node.
+    /// </summary>
+    /// <param name="item">The boxed node whose key is to be retrieved.</param>
+    /// <typeparam name="TSelf">The type of the child node.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <returns>The key of the node.</returns>
+    public static TKey Key<TSelf, TKey>(this Box<TSelf> item)
+        where TSelf : struct, IHaveKey<TKey>
+        => item.Item.Key;
+}

--- a/src/NexusMods.Paths/Trees/Traits/IHaveKey.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveKey.cs
@@ -1208,6 +1208,18 @@ public static class IHaveKeyExtensions
     /// <typeparam name="TSelf">The type of the child node.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
     /// <returns>The key of the node.</returns>
+    public static TKey Key<TSelf, TKey>(this KeyValuePair<TKey, KeyedBox<TKey, TSelf>> item)
+        where TSelf : struct, IHaveKey<TKey>
+        where TKey : notnull
+        => item.Value.Item.Key;
+
+    /// <summary>
+    ///     Retrieves the key of the node.
+    /// </summary>
+    /// <param name="item">The keyed boxed node whose key is to be retrieved.</param>
+    /// <typeparam name="TSelf">The type of the child node.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <returns>The key of the node.</returns>
     public static TKey Key<TSelf, TKey>(this KeyedBox<TKey, TSelf> item)
         where TSelf : struct, IHaveKey<TKey>
         where TKey : notnull

--- a/src/NexusMods.Paths/Trees/Traits/IHaveKey.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveKey.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using NexusMods.Paths.Trees.Traits.Interfaces;
 using Reloaded.Memory.Extensions;
 
 namespace NexusMods.Paths.Trees.Traits;
@@ -90,13 +91,13 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildren
     /// <summary>
     ///     Recursively returns all the keys of the children of this node.
     /// </summary>
-    /// <param name="item">The node whose child keys to obtain.</param>
+    /// <param name="item">The boxed node whose child keys to obtain.</param>
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
     /// <returns>An array of all the keys of the children of this node.</returns>
     public static TKey[] GetKeys<TSelf, TKey>(this Box<TSelf> item)
-        where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveKey<TKey>
-        => item.Item.GetKeys<TSelf, TKey>();
+        where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveKey<TKey> =>
+        item.Item.GetChildItems<TSelf, TKey, KeySelector<TSelf, TKey>>(new KeySelector<TSelf, TKey>());
 
     /// <summary>
     ///     Recursively returns all the keys of the children of this node.
@@ -105,15 +106,10 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildren
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
     /// <returns>An array of all the keys of the children of this node.</returns>
+    [ExcludeFromCodeCoverage]
     public static TKey[] GetKeys<TSelf, TKey>(this TSelf item)
-        where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveKey<TKey>
-    {
-        var totalKeys = item.CountChildren(); // Ensure this method counts all descendants.
-        var keys = GC.AllocateUninitializedArray<TKey>(totalKeys);
-        var index = 0;
-        GetKeysUnsafe<TSelf, TKey>(item, keys, ref index);
-        return keys;
-    }
+        where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveKey<TKey> =>
+        item.GetChildItems<TSelf, TKey, KeySelector<TSelf, TKey>>(new KeySelector<TSelf, TKey>());
 
     /// <summary>
     ///     Helper method to populate keys recursively.
@@ -124,17 +120,10 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildren
     ///     Should be at least as big as <see cref="IHaveBoxedChildrenExtensions.CountChildren{TSelf}(Box{TSelf})"/>
     /// </param>
     /// <param name="index">The current index in the array.</param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [ExcludeFromCodeCoverage]
     public static void GetKeysUnsafe<TSelf, TKey>(TSelf item, Span<TKey> buffer, ref int index)
-        where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveKey<TKey>
-    {
-        // Populate breadth first. Improved cache locality helps here.
-        foreach (var child in item.Children)
-            buffer.DangerousGetReferenceAt(index++) = child.Item.Key;
-
-        foreach (var child in item.Children)
-            GetKeysUnsafe(child.Item, buffer, ref index);
-    }
+        where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveKey<TKey> =>
+        item.GetChildItemsUnsafe(new KeySelector<TSelf, TKey>(), buffer, ref index);
 
     /// <summary>
     ///     Finds a node in the tree based on a given sequence of keys, starting the search from the root node.
@@ -516,13 +505,13 @@ public static class IHaveKeyExtensionsForIHaveObservableChildren
     /// <summary>
     ///     Recursively returns all the keys of the children of this node.
     /// </summary>
-    /// <param name="item">The node whose child keys to obtain.</param>
+    /// <param name="item">The boxed node whose child keys to obtain.</param>
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
     /// <returns>An array of all the keys of the children of this node.</returns>
     public static TKey[] GetKeys<TSelf, TKey>(this Box<TSelf> item)
-        where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveKey<TKey>
-        => item.Item.GetKeys<TSelf, TKey>();
+        where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveKey<TKey> =>
+        item.Item.GetChildItems<TSelf, TKey, KeySelector<TSelf, TKey>>(new KeySelector<TSelf, TKey>());
 
     /// <summary>
     ///     Recursively returns all the keys of the children of this node.
@@ -531,15 +520,10 @@ public static class IHaveKeyExtensionsForIHaveObservableChildren
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
     /// <returns>An array of all the keys of the children of this node.</returns>
+    [ExcludeFromCodeCoverage]
     public static TKey[] GetKeys<TSelf, TKey>(this TSelf item)
-        where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveKey<TKey>
-    {
-        var totalKeys = item.CountChildren(); // Ensure this method counts all descendants.
-        var keys = GC.AllocateUninitializedArray<TKey>(totalKeys);
-        var index = 0;
-        GetKeysUnsafe<TSelf, TKey>(item, keys, ref index);
-        return keys;
-    }
+        where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveKey<TKey> =>
+        item.GetChildItems<TSelf, TKey, KeySelector<TSelf, TKey>>(new KeySelector<TSelf, TKey>());
 
     /// <summary>
     ///     Helper method to populate keys recursively.
@@ -547,20 +531,13 @@ public static class IHaveKeyExtensionsForIHaveObservableChildren
     /// <param name="item">The current node.</param>
     /// <param name="buffer">
     ///     The span to fill with keys.
-    ///     If calling on root node, should be at least as big as <see cref="IHaveObservableChildrenExtensions.CountChildren{TSelf}(Box{TSelf})"/>
+    ///     Should be at least as big as <see cref="IHaveBoxedChildrenExtensions.CountChildren{TSelf}(Box{TSelf})"/>
     /// </param>
     /// <param name="index">The current index in the array.</param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [ExcludeFromCodeCoverage]
     public static void GetKeysUnsafe<TSelf, TKey>(TSelf item, Span<TKey> buffer, ref int index)
-        where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveKey<TKey>
-    {
-        // Populate breadth first. Improved cache locality helps here.
-        foreach (var child in item.Children)
-            buffer.DangerousGetReferenceAt(index++) = child.Item.Key;
-
-        foreach (var child in item.Children)
-            GetKeysUnsafe(child.Item, buffer, ref index);
-    }
+        where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveKey<TKey> =>
+        item.GetChildItemsUnsafe(new KeySelector<TSelf, TKey>(), buffer, ref index);
 
     /// <summary>
     ///     Finds a node in the tree based on a given sequence of keys, starting the search from the root node.
@@ -941,55 +918,44 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildrenWithKey
     }
 
     /// <summary>
-    ///     Returns all the keys of the children of this node (using recursion).
+    ///     Recursively returns all the keys of the children of this node.
     /// </summary>
-    /// <param name="item">The node whose child keys to obtain.</param>
-    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <param name="item">The boxed node with keyed children whose keys to obtain.</param>
     /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <returns>An array of all the keys of the children of this node.</returns>
-    public static TKey[] GetKeys<TSelf, TKey>(this KeyedBox<TKey, TSelf> item)
+    public static TKey[] GetKeys<TKey, TSelf>(this KeyedBox<TKey, TSelf> item)
         where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveKey<TKey>
-        where TKey : notnull =>
-        item.Item.GetKeys<TSelf, TKey>();
+        where TKey : struct =>
+        item.GetChildItems<TKey, TSelf, TKey, KeySelector<TSelf, TKey>>(new KeySelector<TSelf, TKey>());
 
     /// <summary>
-    ///     Returns all the keys of the children of this node (using recursion).
+    ///     Recursively returns all the keys of the children of this node.
     /// </summary>
-    /// <param name="item">The node whose child keys to obtain.</param>
-    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <param name="item">The node with keyed children whose keys to obtain.</param>
     /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <returns>An array of all the keys of the children of this node.</returns>
-    public static TKey[] GetKeys<TSelf, TKey>(this TSelf item)
+    [ExcludeFromCodeCoverage]
+    public static TKey[] GetKeys<TKey, TSelf>(this TSelf item)
         where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveKey<TKey>
-        where TKey : notnull
-    {
-        var totalChildren = item.CountChildren<TSelf, TKey>(); // Ensure CountChildren counts all descendants.
-        var keys = GC.AllocateUninitializedArray<TKey>(totalChildren);
-        var index = 0;
-        GetKeysUnsafe<TSelf, TKey>(item, keys, ref index);
-        return keys;
-    }
+        where TKey : struct =>
+        item.GetChildItems<TKey, TSelf, TKey, KeySelector<TSelf, TKey>>(new KeySelector<TSelf, TKey>());
 
     /// <summary>
     ///     Helper method to populate keys recursively.
     /// </summary>
-    /// <param name="item">The current node.</param>
+    /// <param name="item">The current node with keyed children.</param>
     /// <param name="buffer">
     ///     The span to fill with keys.
-    ///     Should be at least as big as <see cref="IHaveBoxedChildrenWithKeyExtensions.CountChildren{TSelf,TKey}(KeyedBox{TKey,TSelf})"/>
+    ///     Should be at least as big as the count of children.
     /// </param>
-    /// <param name="index">The current index in the span.</param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void GetKeysUnsafe<TSelf, TKey>(TSelf item, Span<TKey> buffer, ref int index)
+    /// <param name="index">The current index in the array.</param>
+    [ExcludeFromCodeCoverage]
+    public static void GetKeysUnsafe<TKey, TSelf>(TSelf item, Span<TKey> buffer, ref int index)
         where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveKey<TKey>
-        where TKey : notnull
-    {
-        foreach (var pair in item.Children)
-        {
-            buffer.DangerousGetReferenceAt(index++) = pair.Key;
-            GetKeysUnsafe(pair.Value.Item, buffer, ref index);
-        }
-    }
+        where TKey : struct, IHaveKey<TSelf> =>
+        item.GetChildItemsUnsafe<TKey, TSelf, TKey, KeySelector<TSelf, TKey>>(new KeySelector<TSelf, TKey>(), buffer, ref index);
 
     /// <summary>
     ///     Finds a node in the tree based on a given relative path of keys, starting the search from the root node.
@@ -1315,4 +1281,10 @@ public static class IHaveKeyExtensions
     public static TKey Key<TSelf, TKey>(this Box<TSelf> item)
         where TSelf : struct, IHaveKey<TKey>
         => item.Item.Key;
+}
+
+internal struct KeySelector<TSelf, TKey> : ISelector<TSelf, TKey>
+    where TSelf : struct, IHaveKey<TKey>
+{
+    public TKey Select(TSelf item) => item.Key;
 }

--- a/src/NexusMods.Paths/Trees/Traits/IHaveKey.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveKey.cs
@@ -44,18 +44,7 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildren
     /// <returns>An IEnumerable of all child keys of the current node.</returns>
     public static IEnumerable<TKey> EnumerateKeysBfs<TSelf, TKey>(this TSelf item)
         where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveKey<TKey>
-    {
-        // First return all keys of the immediate children
-        foreach (var child in item.Children)
-            yield return child.Item.Key;
-
-        // Then iterate over the immediate children and recursively enumerate their keys
-        foreach (var child in item.Children)
-        {
-            foreach (var grandChildKey in child.Item.EnumerateKeysBfs<TSelf, TKey>())
-                yield return grandChildKey;
-        }
-    }
+        => item.EnumerateChildrenBfs<TSelf, TKey, BoxKeySelector<TSelf, TKey>>();
 
     /// <summary>
     ///     Enumerates all keys of the child nodes of the current node in a depth-first manner.
@@ -77,15 +66,7 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildren
     /// <returns>An IEnumerable of all child keys of the current node.</returns>
     public static IEnumerable<TKey> EnumerateKeysDfs<TSelf, TKey>(this TSelf item)
         where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveKey<TKey>
-    {
-        // Enumerate the key of each child and then recursively enumerate the keys of its children
-        foreach (var child in item.Children)
-        {
-            yield return child.Item.Key;
-            foreach (var grandChildKey in child.Item.EnumerateKeysDfs<TSelf, TKey>())
-                yield return grandChildKey;
-        }
-    }
+        => item.EnumerateChildrenDfs<TSelf, TKey, BoxKeySelector<TSelf, TKey>>();
 
     /// <summary>
     ///     Recursively returns all the keys of the children of this node.
@@ -458,18 +439,7 @@ public static class IHaveKeyExtensionsForIHaveObservableChildren
     /// <returns>An IEnumerable of all child keys of the current node.</returns>
     public static IEnumerable<TKey> EnumerateKeysBfs<TSelf, TKey>(this TSelf item)
         where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveKey<TKey>
-    {
-        // First return all keys of the immediate children
-        foreach (var child in item.Children)
-            yield return child.Item.Key;
-
-        // Then iterate over the immediate children and recursively enumerate their keys
-        foreach (var child in item.Children)
-        {
-            foreach (var grandChildKey in child.Item.EnumerateKeysBfs<TSelf, TKey>())
-                yield return grandChildKey;
-        }
-    }
+        => item.EnumerateChildrenBfs<TSelf, TKey, BoxKeySelector<TSelf, TKey>>();
 
     /// <summary>
     ///     Enumerates all keys of the child nodes of the current node in a depth-first manner.
@@ -491,15 +461,7 @@ public static class IHaveKeyExtensionsForIHaveObservableChildren
     /// <returns>An IEnumerable of all child keys of the current node.</returns>
     public static IEnumerable<TKey> EnumerateKeysDfs<TSelf, TKey>(this TSelf item)
         where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveKey<TKey>
-    {
-        // Enumerate the key of each child and then recursively enumerate the keys of its children
-        foreach (var child in item.Children)
-        {
-            yield return child.Item.Key;
-            foreach (var grandChildKey in child.Item.EnumerateKeysDfs<TSelf, TKey>())
-                yield return grandChildKey;
-        }
-    }
+        => item.EnumerateChildrenDfs<TSelf, TKey, BoxKeySelector<TSelf, TKey>>();
 
     /// <summary>
     ///     Recursively returns all the keys of the children of this node.
@@ -871,18 +833,7 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildrenWithKey
     public static IEnumerable<TKey> EnumerateKeysBfs<TSelf, TKey>(this TSelf item)
         where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveKey<TKey>
         where TKey : notnull
-    {
-        // First return all keys of the immediate children
-        foreach (var child in item.Children)
-            yield return child.Value.Item.Key;
-
-        // Then iterate over the immediate children and recursively enumerate their keys
-        foreach (var child in item.Children)
-        {
-            foreach (var grandChildKey in child.Value.Item.EnumerateKeysBfs<TSelf, TKey>())
-                yield return grandChildKey;
-        }
-    }
+        => item.EnumerateChildrenBfs<TSelf, TKey, TKey, KeyValueKeySelector<TSelf, TKey>>();
 
     /// <summary>
     ///     Enumerates all keys of the child nodes of the current node in a depth-first manner.
@@ -906,15 +857,7 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildrenWithKey
     public static IEnumerable<TKey> EnumerateKeysDfs<TSelf, TKey>(this TSelf item)
         where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveKey<TKey>
         where TKey : notnull
-    {
-        // Enumerate the key of each child and then recursively enumerate the keys of its children
-        foreach (var child in item.Children)
-        {
-            yield return child.Value.Item.Key;
-            foreach (var grandChildKey in child.Value.Item.EnumerateKeysDfs<TSelf, TKey>())
-                yield return grandChildKey;
-        }
-    }
+        => item.EnumerateChildrenDfs<TSelf, TKey, TKey, KeyValueKeySelector<TSelf, TKey>>();
 
     /// <summary>
     ///     Recursively returns all the keys of the children of this node.
@@ -923,7 +866,7 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildrenWithKey
     /// <typeparam name="TKey">The type of the key.</typeparam>
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <returns>An array of all the keys of the children of this node.</returns>
-    public static TKey[] GetKeys<TKey, TSelf>(this KeyedBox<TKey, TSelf> item)
+    public static TKey[] GetKeys<TSelf, TKey>(this KeyedBox<TKey, TSelf> item)
         where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveKey<TKey>
         where TKey : struct =>
         item.GetChildrenRecursive<TSelf, TKey, TKey, KeySelector<TSelf, TKey>>();
@@ -936,7 +879,7 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildrenWithKey
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <returns>An array of all the keys of the children of this node.</returns>
     [ExcludeFromCodeCoverage]
-    public static TKey[] GetKeys<TKey, TSelf>(this TSelf item)
+    public static TKey[] GetKeys<TSelf, TKey>(this TSelf item)
         where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveKey<TKey>
         where TKey : struct =>
         item.GetChildrenRecursive<TSelf, TKey, TKey, KeySelector<TSelf, TKey>>();
@@ -951,7 +894,7 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildrenWithKey
     /// </param>
     /// <param name="index">The current index in the array.</param>
     [ExcludeFromCodeCoverage]
-    public static void GetKeysUnsafe<TKey, TSelf>(TSelf item, Span<TKey> buffer, ref int index)
+    public static void GetKeysUnsafe<TSelf, TKey>(TSelf item, Span<TKey> buffer, ref int index)
         where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveKey<TKey>
         where TKey : struct, IHaveKey<TSelf> =>
         item.GetChildrenRecursiveUnsafe<TSelf, TKey, TKey, KeySelector<TSelf, TKey>>(buffer, ref index);
@@ -1280,6 +1223,19 @@ public static class IHaveKeyExtensions
     public static TKey Key<TSelf, TKey>(this Box<TSelf> item)
         where TSelf : struct, IHaveKey<TKey>
         => item.Item.Key;
+}
+
+internal struct BoxKeySelector<TSelf, TKey> : ISelector<Box<TSelf>, TKey>
+    where TSelf : struct, IHaveKey<TKey>
+{
+    public static TKey Select(Box<TSelf> item) => item.Item.Key;
+}
+
+internal struct KeyValueKeySelector<TSelf, TKey> : ISelector<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>, TKey>
+    where TSelf : struct, IHaveKey<TKey>
+    where TKey : notnull
+{
+    public static TKey Select(KeyValuePair<TKey, KeyedBox<TKey, TSelf>> item) => item.Value.Key();
 }
 
 internal struct KeySelector<TSelf, TKey> : ISelector<TSelf, TKey>

--- a/src/NexusMods.Paths/Trees/Traits/IHaveKey.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveKey.cs
@@ -367,7 +367,7 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildren
         where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveKey<TKey>, IHaveParent<TSelf>
         where TKey : notnull
     {
-        if (node.FindByKeysUpward(keys) != null)
+        if (node.FindByKeyUpward(keys) != null)
             foundNodes.Add(node);
 
         foreach (var child in node.Item.Children)
@@ -722,7 +722,7 @@ public static class IHaveKeyExtensionsForIHaveObservableChildren
         where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveKey<TKey>, IHaveParent<TSelf>
         where TKey : notnull
     {
-        if (node.FindByKeysUpward(keys) != null)
+        if (node.FindByKeyUpward(keys) != null)
             foundNodes.Add(node);
 
         foreach (var child in node.Item.Children)
@@ -1073,7 +1073,7 @@ public static class IHaveKeyExtensionsForIHaveBoxedChildrenWithKey
         where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveKey<TKey>, IHaveParent<TSelf>
         where TKey : notnull
     {
-        if (node.FindByKeysUpward(keys) != null)
+        if (node.FindByKeyUpward(keys) != null)
             foundNodes.Add(node);
 
         foreach (var child in node.Item.Children)

--- a/src/NexusMods.Paths/Trees/Traits/IHaveObservableChildren.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveObservableChildren.cs
@@ -100,36 +100,34 @@ public static class IHaveObservableChildrenExtensions
     ///     Enumerates all child nodes of the current node in a breadth-first manner that satisfy a given filter.
     /// </summary>
     /// <param name="item">The node, wrapped in a Box, whose children are to be enumerated.</param>
-    /// <param name="filter">The filter struct to be applied to each child node.</param>
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
     /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
     [ExcludeFromCodeCoverage] // Wrapper
-    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredBfs<TSelf, TFilter>(this Box<TSelf> item, TFilter filter)
+    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredBfs<TSelf, TFilter>(this Box<TSelf> item)
         where TSelf : struct, IHaveObservableChildren<TSelf>
         where TFilter : struct, IFilter<Box<TSelf>>
-        => item.Item.EnumerateChildrenFilteredBfs(filter);
+        => item.Item.EnumerateChildrenFilteredBfs<TSelf, TFilter>();
 
     /// <summary>
     ///     Enumerates all child nodes of the current node in a breadth-first manner that satisfy a given filter.
     /// </summary>
     /// <param name="item">The node whose children are to be enumerated.</param>
-    /// <param name="filter">The filter struct to be applied to each child node.</param>
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
     /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
-    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredBfs<TSelf, TFilter>(this TSelf item, TFilter filter)
+    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredBfs<TSelf, TFilter>(this TSelf item)
         where TSelf : struct, IHaveObservableChildren<TSelf>
         where TFilter : struct, IFilter<Box<TSelf>>
     {
         // Return the current item's immediate children first if they match the filter.
         foreach (var child in item.Children)
-            if (filter.Match(child))
+            if (TFilter.Match(child))
                 yield return child;
 
         // Then return the filtered children of those children.
         foreach (var child in item.Children)
-        foreach (var grandChild in child.Item.EnumerateChildrenFilteredBfs(filter))
+        foreach (var grandChild in child.Item.EnumerateChildrenFilteredBfs<TSelf, TFilter>())
             yield return grandChild;
     }
 
@@ -137,34 +135,32 @@ public static class IHaveObservableChildrenExtensions
     ///     Enumerates all child nodes of the current node in a depth-first manner that satisfy a given filter.
     /// </summary>
     /// <param name="item">The node, wrapped in a Box, whose children are to be enumerated.</param>
-    /// <param name="filter">The filter struct to be applied to each child node.</param>
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
     /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
     [ExcludeFromCodeCoverage] // Wrapper
-    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredDfs<TSelf, TFilter>(this Box<TSelf> item, TFilter filter)
+    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredDfs<TSelf, TFilter>(this Box<TSelf> item)
         where TSelf : struct, IHaveObservableChildren<TSelf>
         where TFilter : struct, IFilter<Box<TSelf>>
-        => item.Item.EnumerateChildrenFilteredDfs(filter);
+        => item.Item.EnumerateChildrenFilteredDfs<TSelf, TFilter>();
 
     /// <summary>
     ///     Enumerates all child nodes of the current node in a depth-first manner that satisfy a given filter.
     /// </summary>
     /// <param name="item">The node whose children are to be enumerated.</param>
-    /// <param name="filter">The filter struct to be applied to each child node.</param>
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
     /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
-    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredDfs<TSelf, TFilter>(this TSelf item, TFilter filter)
+    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredDfs<TSelf, TFilter>(this TSelf item)
         where TSelf : struct, IHaveObservableChildren<TSelf>
         where TFilter : struct, IFilter<Box<TSelf>>
     {
         foreach (var child in item.Children)
         {
-            if (filter.Match(child))
+            if (TFilter.Match(child))
                 yield return child;
 
-            foreach (var grandChild in child.Item.EnumerateChildrenFilteredDfs(filter))
+            foreach (var grandChild in child.Item.EnumerateChildrenFilteredDfs<TSelf, TFilter>())
                 yield return grandChild;
         }
     }
@@ -173,44 +169,43 @@ public static class IHaveObservableChildrenExtensions
     ///     Counts the number of children that match the given filter under this node.
     /// </summary>
     /// <param name="item">The node whose children are to be counted.</param>
-    /// <param name="filter">The filter to apply to each child.</param>
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TFilter">The type of the filter.</typeparam>
     /// <returns>The total count of children that match the filter under this node.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int CountChildren<TSelf, TFilter>(this Box<TSelf> item, TFilter filter)
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static int CountChildren<TSelf, TFilter>(this Box<TSelf> item)
         where TSelf : struct, IHaveObservableChildren<TSelf>
         where TFilter : struct, IFilter<TSelf>
-        => item.Item.CountChildren(filter);
+        => item.Item.CountChildren<TSelf, TFilter>();
 
     /// <summary>
     ///     Counts the number of children that match the given filter under this node.
     /// </summary>
     /// <param name="item">The node whose children are to be counted.</param>
-    /// <param name="filter">The filter to apply to each child.</param>
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TFilter">The type of the filter.</typeparam>
     /// <returns>The total count of children that match the filter under this node.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int CountChildren<TSelf, TFilter>(this TSelf item, TFilter filter)
+    public static int CountChildren<TSelf, TFilter>(this TSelf item)
         where TSelf : struct, IHaveObservableChildren<TSelf>
         where TFilter : struct, IFilter<TSelf>
     {
         var result = 0;
-        item.CountChildrenRecursive(ref result, filter);
+        item.CountChildrenRecursive<TSelf, TFilter>(ref result);
         return result;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void CountChildrenRecursive<TSelf, TFilter>(this TSelf item, ref int accumulator, TFilter filter)
+    private static void CountChildrenRecursive<TSelf, TFilter>(this TSelf item, ref int accumulator)
         where TSelf : struct, IHaveObservableChildren<TSelf>
         where TFilter : struct, IFilter<TSelf>
     {
         foreach (var child in item.Children)
         {
-            var matchesFilter = filter.Match(child.Item);
+            var matchesFilter = TFilter.Match(child.Item);
             accumulator += Unsafe.As<bool, byte>(ref matchesFilter); // Branchless increment.
-            child.Item.CountChildrenRecursive(ref accumulator, filter);
+            child.Item.CountChildrenRecursive<TSelf, TFilter>(ref accumulator);
         }
     }
 
@@ -251,34 +246,32 @@ public static class IHaveObservableChildrenExtensions
     ///     Recursively returns all the child items of this node selected by the given selector.
     /// </summary>
     /// <param name="item">The boxed node whose child items to obtain.</param>
-    /// <param name="selector">The selector to determine which child items to return.</param>
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <typeparam name="TSelector">The type of the selector.</typeparam>
     /// <returns>An array of all the selected child items of this node.</returns>
     [ExcludeFromCodeCoverage]
-    public static TResult[] GetChildItems<TSelf, TResult, TSelector>(this Box<TSelf> item, TSelector selector)
+    public static TResult[] GetChildrenRecursive<TSelf, TResult, TSelector>(this Box<TSelf> item)
         where TSelf : struct, IHaveObservableChildren<TSelf>
         where TSelector : struct, ISelector<TSelf, TResult>
-        => item.Item.GetChildItems<TSelf, TResult, TSelector>(selector);
+        => item.Item.GetChildrenRecursive<TSelf, TResult, TSelector>();
 
     /// <summary>
     ///     Recursively returns all the child items of this node selected by the given selector.
     /// </summary>
     /// <param name="item">The node whose child items to obtain.</param>
-    /// <param name="selector">The selector to determine which child items to return.</param>
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <typeparam name="TSelector">The type of the selector.</typeparam>
     /// <returns>An array of all the selected child items of this node.</returns>
-    public static TResult[] GetChildItems<TSelf, TResult, TSelector>(this TSelf item, TSelector selector)
+    public static TResult[] GetChildrenRecursive<TSelf, TResult, TSelector>(this TSelf item)
         where TSelf : struct, IHaveObservableChildren<TSelf>
         where TSelector : struct, ISelector<TSelf, TResult>
     {
         var totalValues = item.CountChildren();
         var results = GC.AllocateUninitializedArray<TResult>(totalValues);
         var index = 0;
-        GetChildItemsUnsafe<TSelf, TResult, TSelector>(item, selector, results, ref index);
+        GetChildrenRecursiveUnsafe<TSelf, TResult, TSelector>(item, results, ref index);
         return results;
     }
 
@@ -286,22 +279,90 @@ public static class IHaveObservableChildrenExtensions
     ///     Helper method to populate child items recursively.
     /// </summary>
     /// <param name="item">The current node.</param>
-    /// <param name="selector">The selector to determine which child items to return.</param>
     /// <param name="buffer">
     ///     The span to fill with child items.
     ///     Should be at least as big as <see cref="IHaveBoxedChildrenExtensions.CountChildren{TSelf}(Box{TSelf})"/>
     /// </param>
     /// <param name="index">The current index in the array.</param>
-    public static void GetChildItemsUnsafe<TSelf, TResult, TSelector>(this TSelf item, TSelector selector, Span<TResult> buffer, ref int index)
+    public static void GetChildrenRecursiveUnsafe<TSelf, TResult, TSelector>(this TSelf item, Span<TResult> buffer, ref int index)
         where TSelf : struct, IHaveObservableChildren<TSelf>
         where TSelector : struct, ISelector<TSelf, TResult>
     {
         // Populate breadth first. Improved cache locality helps here.
         foreach (var child in item.Children)
-            buffer.DangerousGetReferenceAt(index++) = selector.Select(child.Item);
+            buffer.DangerousGetReferenceAt(index++) = TSelector.Select(child.Item);
 
         foreach (var child in item.Children)
-            GetChildItemsUnsafe(child.Item, selector, buffer, ref index);
+            GetChildrenRecursiveUnsafe<TSelf, TResult, TSelector>(child.Item, buffer, ref index);
+    }
+
+    /// <summary>
+    ///     Recursively returns all the child items of this node that match the given filter, transformed by the selector.
+    /// </summary>
+    /// <param name="item">The boxed node whose child items to obtain.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An array of all the transformed child items of this node that match the filter.</returns>
+    public static TResult[] GetChildrenRecursive<TSelf, TResult, TFilter, TSelector>(this Box<TSelf> item)
+        where TSelf : struct, IHaveObservableChildren<TSelf>
+        where TFilter : struct, IFilter<TSelf>
+        where TSelector : struct, ISelector<TSelf, TResult>
+        => item.Item.GetChildrenRecursive<TSelf, TResult, TFilter, TSelector>();
+
+    /// <summary>
+    /// Recursively returns all the child items of this node that match the given filter, transformed by the selector.
+    /// </summary>
+    /// <param name="item">The node whose child items to obtain.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An array of all the transformed child items of this node that match the filter.</returns>
+    public static TResult[] GetChildrenRecursive<TSelf, TResult, TFilter, TSelector>(this TSelf item)
+        where TSelf : struct, IHaveObservableChildren<TSelf>
+        where TFilter : struct, IFilter<TSelf>
+        where TSelector : struct, ISelector<TSelf, TResult>
+    {
+        var totalChildren = item.CountChildren<TSelf, TFilter>();
+        var results = GC.AllocateUninitializedArray<TResult>(totalChildren);
+        var index = 0;
+        GetChildrenRecursiveUnsafe<TSelf, TResult, TFilter, TSelector>(item, results, ref index);
+        return results;
+    }
+
+    /// <summary>
+    ///     Helper method to populate transformed child items recursively, filtered by the given filter.
+    /// </summary>
+    /// <param name="item">The current node.</param>
+    /// <param name="buffer">The span to fill with transformed child items.</param>
+    /// <param name="index">The current index in the span.</param>
+    public static void GetChildrenRecursiveUnsafe<TSelf, TResult, TFilter, TSelector>(this Box<TSelf> item,
+        Span<TResult> buffer, ref int index)
+        where TSelf : struct, IHaveObservableChildren<TSelf>
+        where TFilter : struct, IFilter<TSelf>
+        where TSelector : struct, ISelector<TSelf, TResult>
+        => item.Item.GetChildrenRecursiveUnsafe<TSelf, TResult, TFilter, TSelector>(buffer, ref index);
+
+    /// <summary>
+    ///     Helper method to populate transformed child items recursively, filtered by the given filter.
+    /// </summary>
+    /// <param name="item">The current node.</param>
+    /// <param name="buffer">The span to fill with transformed child items.</param>
+    /// <param name="index">The current index in the span.</param>
+    public static void GetChildrenRecursiveUnsafe<TSelf, TResult, TFilter, TSelector>(this TSelf item, Span<TResult> buffer, ref int index)
+        where TSelf : struct, IHaveObservableChildren<TSelf>
+        where TFilter : struct, IFilter<TSelf>
+        where TSelector : struct, ISelector<TSelf, TResult>
+    {
+        foreach (var child in item.Children)
+        {
+            if (TFilter.Match(child.Item))
+                buffer.DangerousGetReferenceAt(index++) = TSelector.Select(child.Item);
+
+            GetChildrenRecursiveUnsafe<TSelf, TResult, TFilter, TSelector>(child.Item, buffer, ref index);
+        }
     }
 
     /// <summary>
@@ -348,6 +409,60 @@ public static class IHaveObservableChildrenExtensions
 
         foreach (var child in item.Children)
             GetChildrenRecursiveUnsafe(child.Item, childrenSpan, ref index);
+    }
+
+    /// <summary>
+    ///     Recursively returns all the children of this node that match the given filter.
+    /// </summary>
+    /// <param name="item">The node whose children to obtain.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">Filter to apply that decides which children should be returned.</typeparam>
+    /// <returns>An array of all the children of this node that match the filter.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static Box<TSelf>[] GetChildrenRecursive<TSelf, TFilter>(this Box<TSelf> item)
+        where TSelf : struct, IHaveObservableChildren<TSelf>
+        where TFilter : struct, IFilter<TSelf>
+        => item.Item.GetChildrenRecursive();
+
+    /// <summary>
+    ///     Recursively returns all the children of this node that match the given filter.
+    /// </summary>
+    /// <param name="item">The node whose children to obtain.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">Filter to apply that decides which children should be returned.</typeparam>
+    /// <returns>An array of all the children of this node that match the filter.</returns>
+    public static Box<TSelf>[] GetChildrenRecursive<TSelf, TFilter>(this TSelf item)
+        where TSelf : struct, IHaveObservableChildren<TSelf>
+        where TFilter : struct, IFilter<TSelf>
+    {
+        var totalChildren = item.CountChildren<TSelf, TFilter>();
+        var children = GC.AllocateUninitializedArray<Box<TSelf>>(totalChildren);
+        var index = 0;
+        GetChildrenRecursiveUnsafe<TSelf, TFilter>(item, children, ref index);
+        return children;
+    }
+
+    /// <summary>
+    ///     Recursively returns all the children of this node (unsafe / no bounds checks).
+    /// </summary>
+    /// <param name="item">The current node.</param>
+    /// <param name="childrenSpan">
+    ///     The span representing the array to fill with children.
+    ///     Should be at least as long as the value returned by <see cref="CountChildren{TSelf,TFilter}(NexusMods.Paths.Trees.Box{TSelf})"/>
+    /// </param>
+    /// <param name="index">The current index in the span.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void GetChildrenRecursiveUnsafe<TSelf, TFilter>(this TSelf item, Span<Box<TSelf>> childrenSpan, ref int index)
+        where TSelf : struct, IHaveObservableChildren<TSelf>
+        where TFilter : struct, IFilter<TSelf>
+    {
+        foreach (var child in item.Children)
+        {
+            if (TFilter.Match(child.Item))
+                childrenSpan.DangerousGetReferenceAt(index++) = child;
+
+            GetChildrenRecursiveUnsafe<TSelf, TFilter>(child.Item, childrenSpan, ref index);
+        }
     }
 
     /// <summary>

--- a/src/NexusMods.Paths/Trees/Traits/IHaveObservableChildren.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveObservableChildren.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using NexusMods.Paths.Trees.Traits.Interfaces;
 using Reloaded.Memory.Extensions;
 
 namespace NexusMods.Paths.Trees.Traits;
@@ -91,6 +92,79 @@ public static class IHaveObservableChildrenExtensions
         {
             yield return child;
             foreach (var grandChild in child.Item.EnumerateChildrenDfs())
+                yield return grandChild;
+        }
+    }
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a breadth-first manner that satisfy a given filter.
+    /// </summary>
+    /// <param name="item">The node, wrapped in a Box, whose children are to be enumerated.</param>
+    /// <param name="filter">The filter struct to be applied to each child node.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredBfs<TSelf, TFilter>(this Box<TSelf> item, TFilter filter)
+        where TSelf : struct, IHaveObservableChildren<TSelf>
+        where TFilter : struct, IFilter<Box<TSelf>>
+        => item.Item.EnumerateChildrenFilteredBfs(filter);
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a breadth-first manner that satisfy a given filter.
+    /// </summary>
+    /// <param name="item">The node whose children are to be enumerated.</param>
+    /// <param name="filter">The filter struct to be applied to each child node.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
+    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredBfs<TSelf, TFilter>(this TSelf item, TFilter filter)
+        where TSelf : struct, IHaveObservableChildren<TSelf>
+        where TFilter : struct, IFilter<Box<TSelf>>
+    {
+        // Return the current item's immediate children first if they match the filter.
+        foreach (var child in item.Children)
+            if (filter.Match(child))
+                yield return child;
+
+        // Then return the filtered children of those children.
+        foreach (var child in item.Children)
+        foreach (var grandChild in child.Item.EnumerateChildrenFilteredBfs(filter))
+            yield return grandChild;
+    }
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a depth-first manner that satisfy a given filter.
+    /// </summary>
+    /// <param name="item">The node, wrapped in a Box, whose children are to be enumerated.</param>
+    /// <param name="filter">The filter struct to be applied to each child node.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredDfs<TSelf, TFilter>(this Box<TSelf> item, TFilter filter)
+        where TSelf : struct, IHaveObservableChildren<TSelf>
+        where TFilter : struct, IFilter<Box<TSelf>>
+        => item.Item.EnumerateChildrenFilteredDfs(filter);
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a depth-first manner that satisfy a given filter.
+    /// </summary>
+    /// <param name="item">The node whose children are to be enumerated.</param>
+    /// <param name="filter">The filter struct to be applied to each child node.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
+    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredDfs<TSelf, TFilter>(this TSelf item, TFilter filter)
+        where TSelf : struct, IHaveObservableChildren<TSelf>
+        where TFilter : struct, IFilter<Box<TSelf>>
+    {
+        foreach (var child in item.Children)
+        {
+            if (filter.Match(child))
+                yield return child;
+
+            foreach (var grandChild in child.Item.EnumerateChildrenFilteredDfs(filter))
                 yield return grandChild;
         }
     }

--- a/src/NexusMods.Paths/Trees/Traits/IHaveObservableChildren.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveObservableChildren.cs
@@ -104,10 +104,10 @@ public static class IHaveObservableChildrenExtensions
     /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
     /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
     [ExcludeFromCodeCoverage] // Wrapper
-    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredBfs<TSelf, TFilter>(this Box<TSelf> item)
+    public static IEnumerable<Box<TSelf>> EnumerateChildrenBfs<TSelf, TFilter>(this Box<TSelf> item)
         where TSelf : struct, IHaveObservableChildren<TSelf>
         where TFilter : struct, IFilter<Box<TSelf>>
-        => item.Item.EnumerateChildrenFilteredBfs<TSelf, TFilter>();
+        => item.Item.EnumerateChildrenBfs<TSelf, TFilter>();
 
     /// <summary>
     ///     Enumerates all child nodes of the current node in a breadth-first manner that satisfy a given filter.
@@ -116,7 +116,7 @@ public static class IHaveObservableChildrenExtensions
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
     /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
-    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredBfs<TSelf, TFilter>(this TSelf item)
+    public static IEnumerable<Box<TSelf>> EnumerateChildrenBfs<TSelf, TFilter>(this TSelf item)
         where TSelf : struct, IHaveObservableChildren<TSelf>
         where TFilter : struct, IFilter<Box<TSelf>>
     {
@@ -127,7 +127,7 @@ public static class IHaveObservableChildrenExtensions
 
         // Then return the filtered children of those children.
         foreach (var child in item.Children)
-        foreach (var grandChild in child.Item.EnumerateChildrenFilteredBfs<TSelf, TFilter>())
+        foreach (var grandChild in child.Item.EnumerateChildrenBfs<TSelf, TFilter>())
             yield return grandChild;
     }
 
@@ -139,10 +139,10 @@ public static class IHaveObservableChildrenExtensions
     /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
     /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
     [ExcludeFromCodeCoverage] // Wrapper
-    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredDfs<TSelf, TFilter>(this Box<TSelf> item)
+    public static IEnumerable<Box<TSelf>> EnumerateChildrenDfs<TSelf, TFilter>(this Box<TSelf> item)
         where TSelf : struct, IHaveObservableChildren<TSelf>
         where TFilter : struct, IFilter<Box<TSelf>>
-        => item.Item.EnumerateChildrenFilteredDfs<TSelf, TFilter>();
+        => item.Item.EnumerateChildrenDfs<TSelf, TFilter>();
 
     /// <summary>
     ///     Enumerates all child nodes of the current node in a depth-first manner that satisfy a given filter.
@@ -151,7 +151,7 @@ public static class IHaveObservableChildrenExtensions
     /// <typeparam name="TSelf">The type of child node.</typeparam>
     /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
     /// <returns>An IEnumerable of all filtered child nodes of the current node.</returns>
-    public static IEnumerable<Box<TSelf>> EnumerateChildrenFilteredDfs<TSelf, TFilter>(this TSelf item)
+    public static IEnumerable<Box<TSelf>> EnumerateChildrenDfs<TSelf, TFilter>(this TSelf item)
         where TSelf : struct, IHaveObservableChildren<TSelf>
         where TFilter : struct, IFilter<Box<TSelf>>
     {
@@ -160,7 +160,158 @@ public static class IHaveObservableChildrenExtensions
             if (TFilter.Match(child))
                 yield return child;
 
-            foreach (var grandChild in child.Item.EnumerateChildrenFilteredDfs<TSelf, TFilter>())
+            foreach (var grandChild in child.Item.EnumerateChildrenDfs<TSelf, TFilter>())
+                yield return grandChild;
+        }
+    }
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a breadth-first manner, transforming each child node using the provided selector.
+    /// </summary>
+    /// <param name="item">The node whose children are to be enumerated and transformed.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed child nodes of the current node.</returns>
+    public static IEnumerable<TResult> EnumerateChildrenBfs<TSelf, TResult, TSelector>(this Box<TSelf> item)
+        where TSelf : struct, IHaveObservableChildren<TSelf>
+        where TSelector : struct, ISelector<Box<TSelf>, TResult>
+        => item.Item.EnumerateChildrenBfs<TSelf, TResult, TSelector>();
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a breadth-first manner, transforming each child node using the provided selector.
+    /// </summary>
+    /// <param name="item">The node whose children are to be enumerated and transformed.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed child nodes of the current node.</returns>
+    public static IEnumerable<TResult> EnumerateChildrenBfs<TSelf, TResult, TSelector>(this TSelf item)
+        where TSelf : struct, IHaveObservableChildren<TSelf>
+        where TSelector : struct, ISelector<Box<TSelf>, TResult>
+    {
+        // Return the current item's immediate children first.
+        foreach (var child in item.Children)
+            yield return TSelector.Select(child);
+
+        // Then return the children of those children.
+        foreach (var child in item.Children)
+        foreach (var grandChild in child.Item.EnumerateChildrenBfs<TSelf, TResult, TSelector>())
+            yield return grandChild;
+    }
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a depth-first manner, transforming each child node using the provided selector.
+    /// </summary>
+    /// <param name="item">The node whose children are to be enumerated and transformed.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed child nodes of the current node.</returns>
+    public static IEnumerable<TResult> EnumerateChildrenDfs<TSelf, TResult, TSelector>(this Box<TSelf> item)
+        where TSelf : struct, IHaveObservableChildren<TSelf>
+        where TSelector : struct, ISelector<Box<TSelf>, TResult>
+        => item.Item.EnumerateChildrenDfs<TSelf, TResult, TSelector>();
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a depth-first manner, transforming each child node using the provided selector.
+    /// </summary>
+    /// <param name="item">The node whose children are to be enumerated and transformed.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed child nodes of the current node.</returns>
+    public static IEnumerable<TResult> EnumerateChildrenDfs<TSelf, TResult, TSelector>(this TSelf item)
+        where TSelf : struct, IHaveObservableChildren<TSelf>
+        where TSelector : struct, ISelector<Box<TSelf>, TResult>
+    {
+        foreach (var child in item.Children)
+        {
+            yield return TSelector.Select(child);
+            foreach (var grandChild in child.Item.EnumerateChildrenDfs<TSelf, TResult, TSelector>())
+                yield return grandChild;
+        }
+    }
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a breadth-first manner that satisfy a given filter,
+    ///     transforming each filtered child node using the provided selector.
+    /// </summary>
+    /// <param name="item">The node, wrapped in a Box, whose filtered children are to be enumerated and transformed.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed and filtered child nodes of the current node.</returns>
+    public static IEnumerable<TResult> EnumerateChildrenBfs<TSelf, TResult, TFilter, TSelector>(this Box<TSelf> item)
+        where TSelf : struct, IHaveObservableChildren<TSelf>
+        where TFilter : struct, IFilter<Box<TSelf>>
+        where TSelector : struct, ISelector<Box<TSelf>, TResult>
+        => item.Item.EnumerateChildrenBfs<TSelf, TResult, TFilter, TSelector>();
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a breadth-first manner that satisfy a given filter,
+    ///     transforming each filtered child node using the provided selector.
+    /// </summary>
+    /// <param name="item">The node, wrapped in a Box, whose filtered children are to be enumerated and transformed.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed and filtered child nodes of the current node.</returns>
+    public static IEnumerable<TResult> EnumerateChildrenBfs<TSelf, TResult, TFilter, TSelector>(this TSelf item)
+        where TSelf : struct, IHaveObservableChildren<TSelf>
+        where TFilter : struct, IFilter<Box<TSelf>>
+        where TSelector : struct, ISelector<Box<TSelf>, TResult>
+    {
+        // Return the current item's immediate children first.
+        foreach (var child in item.Children)
+            if (TFilter.Match(child))
+                yield return TSelector.Select(child);
+
+        // Then return the children of those children.
+        foreach (var child in item.Children)
+        foreach (var grandChild in child.Item.EnumerateChildrenBfs<TSelf, TResult, TFilter, TSelector>())
+            yield return grandChild;
+    }
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a depth-first manner that satisfy a given filter,
+    ///     transforming each filtered child node using the provided selector.
+    /// </summary>
+    /// <param name="item">The node, wrapped in a Box, whose filtered children are to be enumerated and transformed.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed and filtered child nodes of the current node.</returns>
+    public static IEnumerable<TResult> EnumerateChildrenDfs<TSelf, TResult, TFilter, TSelector>(this Box<TSelf> item)
+        where TSelf : struct, IHaveObservableChildren<TSelf>
+        where TFilter : struct, IFilter<Box<TSelf>>
+        where TSelector : struct, ISelector<Box<TSelf>, TResult>
+        => item.Item.EnumerateChildrenDfs<TSelf, TResult, TFilter, TSelector>();
+
+    /// <summary>
+    ///     Enumerates all child nodes of the current node in a depth-first manner that satisfy a given filter,
+    ///     transforming each filtered child node using the provided selector.
+    /// </summary>
+    /// <param name="item">The node, wrapped in a Box, whose filtered children are to be enumerated and transformed.</param>
+    /// <typeparam name="TSelf">The type of child node.</typeparam>
+    /// <typeparam name="TFilter">The type of the filter struct.</typeparam>
+    /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
+    /// <typeparam name="TSelector">The type of the selector.</typeparam>
+    /// <returns>An IEnumerable of transformed and filtered child nodes of the current node.</returns>
+    public static IEnumerable<TResult> EnumerateChildrenDfs<TSelf, TResult, TFilter, TSelector>(this TSelf item)
+        where TSelf : struct, IHaveObservableChildren<TSelf>
+        where TFilter : struct, IFilter<Box<TSelf>>
+        where TSelector : struct, ISelector<Box<TSelf>, TResult>
+    {
+        foreach (var child in item.Children)
+        {
+            if (TFilter.Match(child))
+                yield return TSelector.Select(child);
+
+            foreach (var grandChild in child.Item.EnumerateChildrenDfs<TSelf, TResult, TFilter, TSelector>())
                 yield return grandChild;
         }
     }
@@ -281,7 +432,7 @@ public static class IHaveObservableChildrenExtensions
     /// <param name="item">The current node.</param>
     /// <param name="buffer">
     ///     The span to fill with child items.
-    ///     Should be at least as big as <see cref="IHaveBoxedChildrenExtensions.CountChildren{TSelf}(Box{TSelf})"/>
+    ///     Should be at least as big as <see cref="IHaveObservableChildrenExtensions.CountChildren{TSelf}(Box{TSelf})"/>
     /// </param>
     /// <param name="index">The current index in the array.</param>
     public static void GetChildrenRecursiveUnsafe<TSelf, TResult, TSelector>(this TSelf item, Span<TResult> buffer, ref int index)

--- a/src/NexusMods.Paths/Trees/Traits/IHaveObservableChildren.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveObservableChildren.cs
@@ -60,14 +60,20 @@ public static class IHaveObservableChildrenExtensions
     /// <returns>An IEnumerable of all child nodes of the current node.</returns>
     public static IEnumerable<Box<TSelf>> EnumerateChildrenBfs<TSelf>(this TSelf item) where TSelf : struct, IHaveObservableChildren<TSelf>
     {
-        // Return the current item's immediate children first.
-        foreach (var child in item.Children)
-            yield return child;
+        var queue = new Queue<Box<TSelf>>();
 
-        // Then return the children of those children.
+        // Enqueue all immediate children
         foreach (var child in item.Children)
-        foreach (var grandChild in child.Item.EnumerateChildrenBfs())
-            yield return grandChild;
+            queue.Enqueue(child);
+
+        while (queue.TryDequeue(out var current))
+        {
+            yield return current;
+
+            // Enqueue children of the current node
+            foreach (var grandChild in current.Item.Children)
+                queue.Enqueue(grandChild);
+        }
     }
 
     /// <summary>
@@ -120,15 +126,18 @@ public static class IHaveObservableChildrenExtensions
         where TSelf : struct, IHaveObservableChildren<TSelf>
         where TFilter : struct, IFilter<Box<TSelf>>
     {
-        // Return the current item's immediate children first if they match the filter.
+        var queue = new Queue<Box<TSelf>>();
         foreach (var child in item.Children)
-            if (TFilter.Match(child))
-                yield return child;
+            queue.Enqueue(child);
 
-        // Then return the filtered children of those children.
-        foreach (var child in item.Children)
-        foreach (var grandChild in child.Item.EnumerateChildrenBfs<TSelf, TFilter>())
-            yield return grandChild;
+        while (queue.TryDequeue(out var current))
+        {
+            if (TFilter.Match(current))
+                yield return current;
+
+            foreach (var grandChild in current.Item.Children)
+                queue.Enqueue(grandChild);
+        }
     }
 
     /// <summary>
@@ -191,14 +200,16 @@ public static class IHaveObservableChildrenExtensions
         where TSelf : struct, IHaveObservableChildren<TSelf>
         where TSelector : struct, ISelector<Box<TSelf>, TResult>
     {
-        // Return the current item's immediate children first.
+        var queue = new Queue<Box<TSelf>>();
         foreach (var child in item.Children)
-            yield return TSelector.Select(child);
+            queue.Enqueue(child);
 
-        // Then return the children of those children.
-        foreach (var child in item.Children)
-        foreach (var grandChild in child.Item.EnumerateChildrenBfs<TSelf, TResult, TSelector>())
-            yield return grandChild;
+        while (queue.TryDequeue(out var current))
+        {
+            yield return TSelector.Select(current);
+            foreach (var grandChild in current.Item.Children)
+                queue.Enqueue(grandChild);
+        }
     }
 
     /// <summary>
@@ -266,15 +277,18 @@ public static class IHaveObservableChildrenExtensions
         where TFilter : struct, IFilter<Box<TSelf>>
         where TSelector : struct, ISelector<Box<TSelf>, TResult>
     {
-        // Return the current item's immediate children first.
+        var queue = new Queue<Box<TSelf>>();
         foreach (var child in item.Children)
-            if (TFilter.Match(child))
-                yield return TSelector.Select(child);
+            queue.Enqueue(child);
 
-        // Then return the children of those children.
-        foreach (var child in item.Children)
-        foreach (var grandChild in child.Item.EnumerateChildrenBfs<TSelf, TResult, TFilter, TSelector>())
-            yield return grandChild;
+        while (queue.TryDequeue(out var current))
+        {
+            if (TFilter.Match(current))
+                yield return TSelector.Select(current);
+
+            foreach (var grandChild in current.Item.Children)
+                queue.Enqueue(grandChild);
+        }
     }
 
     /// <summary>

--- a/src/NexusMods.Paths/Trees/Traits/IHaveObservableChildren.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveObservableChildren.cs
@@ -173,6 +173,7 @@ public static class IHaveObservableChildrenExtensions
     /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
     /// <typeparam name="TSelector">The type of the selector.</typeparam>
     /// <returns>An IEnumerable of transformed child nodes of the current node.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
     public static IEnumerable<TResult> EnumerateChildrenBfs<TSelf, TResult, TSelector>(this Box<TSelf> item)
         where TSelf : struct, IHaveObservableChildren<TSelf>
         where TSelector : struct, ISelector<Box<TSelf>, TResult>
@@ -208,6 +209,7 @@ public static class IHaveObservableChildrenExtensions
     /// <typeparam name="TResult">The result type after applying the selector.</typeparam>
     /// <typeparam name="TSelector">The type of the selector.</typeparam>
     /// <returns>An IEnumerable of transformed child nodes of the current node.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
     public static IEnumerable<TResult> EnumerateChildrenDfs<TSelf, TResult, TSelector>(this Box<TSelf> item)
         where TSelf : struct, IHaveObservableChildren<TSelf>
         where TSelector : struct, ISelector<Box<TSelf>, TResult>

--- a/src/NexusMods.Paths/Trees/Traits/IHaveObservableChildren.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveObservableChildren.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Reloaded.Memory.Extensions;
 
@@ -262,4 +263,15 @@ public static class IHaveObservableChildrenExtensions
                 GetLeavesUnsafe(child.Item, leavesSpan, ref index);
         }
     }
+
+    /// <summary>
+    ///     Retrieves the observable collection containing all the children of the current node.
+    /// </summary>
+    /// <param name="item">The boxed node whose children are to be retrieved.</param>
+    /// <typeparam name="TSelf">The type of the child node stored in this FileTree.</typeparam>
+    /// <returns>An observable collection of the direct children of the current node.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static ObservableCollection<Box<TSelf>> Children<TSelf>(this Box<TSelf> item)
+        where TSelf : struct, IHaveObservableChildren<TSelf>
+        => item.Item.Children;
 }

--- a/src/NexusMods.Paths/Trees/Traits/IHaveParent.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveParent.cs
@@ -552,20 +552,67 @@ public static class IHaveParentExtensionsForIHaveBoxedChildrenWithKey
 public static class IHaveParentExtensions
 {
     /// <summary>
-    ///      Returns true if the tree has a parent.
+    ///     Gets the parent of the given boxed item.
     /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool HasParent<TSelf>(this TSelf item)
+    /// <param name="item">The boxed item whose parent is to be retrieved.</param>
+    /// <returns>The parent of the item, or null if it is the root.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static Box<TSelf>? Parent<TSelf>(this Box<TSelf> item)
         where TSelf : struct, IHaveParent<TSelf>
-        => item.HasParent;
+        => item.Item.Parent;
 
     /// <summary>
-    ///      Returns true if this is the root of the tree.
+    ///     Checks if the given boxed item has a parent.
     /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool IsTreeRoot<TSelf>(this TSelf item)
+    /// <param name="item">The boxed item to check.</param>
+    /// <returns>True if the item has a parent; otherwise, false.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static bool HasParent<TSelf>(this Box<TSelf> item)
         where TSelf : struct, IHaveParent<TSelf>
-        => item.IsTreeRoot;
+        => item.Item.HasParent;
+
+    /// <summary>
+    ///     Checks if the given boxed item is the root of the tree.
+    /// </summary>
+    /// <param name="item">The boxed item to check.</param>
+    /// <returns>True if the item is the root of the tree; otherwise, false.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static bool IsTreeRoot<TSelf>(this Box<TSelf> item)
+        where TSelf : struct, IHaveParent<TSelf>
+        => item.Item.IsTreeRoot;
+
+    /// <summary>
+    ///     Gets the parent of the given keyed boxed item.
+    /// </summary>
+    /// <param name="item">The keyed boxed item whose parent is to be retrieved.</param>
+    /// <returns>The parent of the item, or null if it is the root.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static Box<TSelf>? Parent<TSelf, TKey>(this KeyedBox<TKey, TSelf> item)
+        where TSelf : struct, IHaveParent<TSelf>
+        where TKey : notnull
+        => item.Item.Parent;
+
+    /// <summary>
+    ///     Checks if the given keyed boxed item has a parent.
+    /// </summary>
+    /// <param name="item">The keyed boxed item to check.</param>
+    /// <returns>True if the item has a parent; otherwise, false.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static bool HasParent<TSelf, TKey>(this KeyedBox<TKey, TSelf> item)
+        where TSelf : struct, IHaveParent<TSelf>
+        where TKey : notnull
+        => item.Item.HasParent;
+
+    /// <summary>
+    ///     Checks if the given keyed boxed item is the root of the tree.
+    /// </summary>
+    /// <param name="item">The keyed boxed item to check.</param>
+    /// <returns>True if the item is the root of the tree; otherwise, false.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static bool IsTreeRoot<TSelf, TKey>(this KeyedBox<TKey, TSelf> item)
+        where TSelf : struct, IHaveParent<TSelf>
+        where TKey : notnull
+        => item.Item.IsTreeRoot;
 
     /// <summary>
     ///     Finds a node by traversing up the parent nodes, matching keys in reverse order.

--- a/src/NexusMods.Paths/Trees/Traits/IHaveParent.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveParent.cs
@@ -587,10 +587,10 @@ public static class IHaveParentExtensions
     /// <param name="item">The keyed boxed item whose parent is to be retrieved.</param>
     /// <returns>The parent of the item, or null if it is the root.</returns>
     [ExcludeFromCodeCoverage] // Wrapper
-    public static Box<TSelf>? Parent<TSelf, TKey>(this KeyValuePair<TKey, KeyedBox<TKey, TSelf>> item)
+    public static KeyedBox<TKey, TSelf>? Parent<TSelf, TKey>(this KeyValuePair<TKey, KeyedBox<TKey, TSelf>> item)
         where TSelf : struct, IHaveParent<TSelf>
         where TKey : notnull
-        => item.Value.Item.Parent;
+        => Unsafe.As<KeyedBox<TKey, TSelf>>(item.Value.Item.Parent);
 
     /// <summary>
     ///     Gets the parent of the given keyed boxed item.
@@ -598,10 +598,10 @@ public static class IHaveParentExtensions
     /// <param name="item">The keyed boxed item whose parent is to be retrieved.</param>
     /// <returns>The parent of the item, or null if it is the root.</returns>
     [ExcludeFromCodeCoverage] // Wrapper
-    public static Box<TSelf>? Parent<TSelf, TKey>(this KeyedBox<TKey, TSelf> item)
+    public static KeyedBox<TKey, TSelf>? Parent<TSelf, TKey>(this KeyedBox<TKey, TSelf> item)
         where TSelf : struct, IHaveParent<TSelf>
         where TKey : notnull
-        => item.Item.Parent;
+        => Unsafe.As<KeyedBox<TKey, TSelf>>(item.Item.Parent);
 
     /// <summary>
     ///     Checks if the given keyed boxed item has a parent.

--- a/src/NexusMods.Paths/Trees/Traits/IHaveParent.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveParent.cs
@@ -706,7 +706,7 @@ public static class IHaveParentExtensions
     /// <param name="keys">The sequence of keys to match, in reverse order.</param>
     /// <returns>The node that matches the sequence of keys from start to end, or null if no match is found.</returns>
     [ExcludeFromCodeCoverage]
-    public static Box<TSelf>? FindRootByKeyUpward<TKey, TSelf>(this KeyedBox<TKey, TSelf> node, Span<TKey> keys)
+    public static Box<TSelf>? FindRootByKeyUpward<TSelf, TKey>(this KeyedBox<TKey, TSelf> node, Span<TKey> keys)
         where TSelf : struct, IHaveParent<TSelf>, IHaveKey<TKey>
         where TKey : notnull
         => ((Box<TSelf>)node).FindRootByKeyUpward(keys);

--- a/src/NexusMods.Paths/Trees/Traits/IHaveParent.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveParent.cs
@@ -587,6 +587,17 @@ public static class IHaveParentExtensions
     /// <param name="item">The keyed boxed item whose parent is to be retrieved.</param>
     /// <returns>The parent of the item, or null if it is the root.</returns>
     [ExcludeFromCodeCoverage] // Wrapper
+    public static Box<TSelf>? Parent<TSelf, TKey>(this KeyValuePair<TKey, KeyedBox<TKey, TSelf>> item)
+        where TSelf : struct, IHaveParent<TSelf>
+        where TKey : notnull
+        => item.Value.Item.Parent;
+
+    /// <summary>
+    ///     Gets the parent of the given keyed boxed item.
+    /// </summary>
+    /// <param name="item">The keyed boxed item whose parent is to be retrieved.</param>
+    /// <returns>The parent of the item, or null if it is the root.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
     public static Box<TSelf>? Parent<TSelf, TKey>(this KeyedBox<TKey, TSelf> item)
         where TSelf : struct, IHaveParent<TSelf>
         where TKey : notnull
@@ -598,10 +609,32 @@ public static class IHaveParentExtensions
     /// <param name="item">The keyed boxed item to check.</param>
     /// <returns>True if the item has a parent; otherwise, false.</returns>
     [ExcludeFromCodeCoverage] // Wrapper
+    public static bool HasParent<TSelf, TKey>(this KeyValuePair<TKey, KeyedBox<TKey, TSelf>> item)
+        where TSelf : struct, IHaveParent<TSelf>
+        where TKey : notnull
+        => item.Value.Item.HasParent;
+
+    /// <summary>
+    ///     Checks if the given keyed boxed item has a parent.
+    /// </summary>
+    /// <param name="item">The keyed boxed item to check.</param>
+    /// <returns>True if the item has a parent; otherwise, false.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
     public static bool HasParent<TSelf, TKey>(this KeyedBox<TKey, TSelf> item)
         where TSelf : struct, IHaveParent<TSelf>
         where TKey : notnull
         => item.Item.HasParent;
+
+    /// <summary>
+    ///     Checks if the given keyed boxed item is the root of the tree.
+    /// </summary>
+    /// <param name="item">The keyed boxed item to check.</param>
+    /// <returns>True if the item is the root of the tree; otherwise, false.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static bool IsTreeRoot<TSelf, TKey>(this KeyValuePair<TKey, KeyedBox<TKey, TSelf>> item)
+        where TSelf : struct, IHaveParent<TSelf>
+        where TKey : notnull
+        => item.Value.Item.IsTreeRoot;
 
     /// <summary>
     ///     Checks if the given keyed boxed item is the root of the tree.

--- a/src/NexusMods.Paths/Trees/Traits/IHavePathSegment.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHavePathSegment.cs
@@ -24,6 +24,30 @@ public interface IHavePathSegment
 public static class IHavePathSegmentExtensions
 {
     /// <summary>
+    ///     Retrieves the key of the node.
+    /// </summary>
+    /// <param name="item">The keyed boxed node whose key is to be retrieved.</param>
+    /// <typeparam name="TSelf">The type of the child node.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <returns>The key of the node.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static RelativePath Key<TSelf, TKey>(this KeyedBox<TKey, TSelf> item)
+        where TSelf : struct, IHavePathSegment
+        where TKey : notnull
+        => item.Item.Segment;
+
+    /// <summary>
+    ///     Retrieves the key of the node.
+    /// </summary>
+    /// <param name="item">The boxed node whose key is to be retrieved.</param>
+    /// <typeparam name="TSelf">The type of the child node.</typeparam>
+    /// <returns>The key of the node.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static RelativePath Key<TSelf>(this Box<TSelf> item)
+        where TSelf : struct, IHavePathSegment
+        => item.Item.Segment;
+
+    /// <summary>
     ///     Reconstructs the full path of the current node by walking up to the root to the tree.
     /// </summary>
     /// <param name="item">The node for which to reconstruct the file path from.</param>

--- a/src/NexusMods.Paths/Trees/Traits/IHavePathSegment.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHavePathSegment.cs
@@ -135,7 +135,7 @@ public static class IHavePathSegmentExtensionsForIHaveBoxedChildren
     ///     This is very slow, at O(N). If you need to use this with large trees, consider using the
     ///     dictionary variant based on <see cref="IHaveBoxedChildrenWithKey{TKey,TSelf}" /> instead.
     /// </remarks>
-    [ExcludeFromCodeCoverage]
+    [ExcludeFromCodeCoverage] // Wrapper
     [Obsolete("This method causes temporary boxing of object. Do not use unless you have no other way to access this item. Use this method via Box<TSelf> instead.")]
     public static Box<TSelf>? FindByPathFromRoot<TSelf>(this TSelf root, RelativePath fullPath)
         where TSelf : struct, IHaveBoxedChildren<TSelf>, IHavePathSegment

--- a/src/NexusMods.Paths/Trees/Traits/IHavePathSegment.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHavePathSegment.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using NexusMods.Paths.Extensions;
 using static Reloaded.Memory.Extensions.SpanExtensions;
@@ -24,26 +25,39 @@ public interface IHavePathSegment
 public static class IHavePathSegmentExtensions
 {
     /// <summary>
-    ///     Retrieves the key of the node.
+    ///     Retrieves the path segment of the node.
     /// </summary>
     /// <param name="item">The keyed boxed node whose key is to be retrieved.</param>
     /// <typeparam name="TSelf">The type of the child node.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
     /// <returns>The key of the node.</returns>
     [ExcludeFromCodeCoverage] // Wrapper
-    public static RelativePath Key<TSelf, TKey>(this KeyedBox<TKey, TSelf> item)
+    public static RelativePath Segment<TSelf, TKey>(this KeyValuePair<TKey, KeyedBox<TKey, TSelf>> item)
+        where TSelf : struct, IHavePathSegment
+        where TKey : notnull
+        => item.Value.Item.Segment;
+
+    /// <summary>
+    ///     Retrieves the path segment of the node.
+    /// </summary>
+    /// <param name="item">The keyed boxed node whose key is to be retrieved.</param>
+    /// <typeparam name="TSelf">The type of the child node.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <returns>The key of the node.</returns>
+    [ExcludeFromCodeCoverage] // Wrapper
+    public static RelativePath Segment<TSelf, TKey>(this KeyedBox<TKey, TSelf> item)
         where TSelf : struct, IHavePathSegment
         where TKey : notnull
         => item.Item.Segment;
 
     /// <summary>
-    ///     Retrieves the key of the node.
+    ///     Retrieves the path segment of the node.
     /// </summary>
     /// <param name="item">The boxed node whose key is to be retrieved.</param>
     /// <typeparam name="TSelf">The type of the child node.</typeparam>
     /// <returns>The key of the node.</returns>
     [ExcludeFromCodeCoverage] // Wrapper
-    public static RelativePath Key<TSelf>(this Box<TSelf> item)
+    public static RelativePath Segment<TSelf>(this Box<TSelf> item)
         where TSelf : struct, IHavePathSegment
         => item.Item.Segment;
 

--- a/src/NexusMods.Paths/Trees/Traits/IHaveValue.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveValue.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Reloaded.Memory.Extensions;
 
 namespace NexusMods.Paths.Trees.Traits;
@@ -328,7 +329,7 @@ public static class IHaveValueExtensionsForIHaveBoxedChildrenWithValue
     }
 
     /// <summary>
-    /// Recursively returns all the values of the children of this node.
+    ///     Recursively returns all the values of the children of this node.
     /// </summary>
     /// <param name="item">The node whose child values to obtain.</param>
     /// <typeparam name="TSelf">The type of child node.</typeparam>
@@ -341,7 +342,7 @@ public static class IHaveValueExtensionsForIHaveBoxedChildrenWithValue
         => item.Item.GetValues<TKey, TSelf, TValue>();
 
     /// <summary>
-    /// Recursively returns all the values of the children of this node.
+    ///     Recursively returns all the values of the children of this node.
     /// </summary>
     /// <param name="item">The node whose child values to obtain.</param>
     /// <typeparam name="TSelf">The type of child node.</typeparam>
@@ -365,7 +366,7 @@ public static class IHaveValueExtensionsForIHaveBoxedChildrenWithValue
     /// <param name="item">The current node.</param>
     /// <param name="buffer">
     ///     The span to fill with values.
-    ///     Should be at least as big as <see cref="IHaveBoxedChildrenWithKeyExtensions.CountChildren{TSelf,TKey}(NexusMods.Paths.Trees.Traits.ChildWithKeyBox{TKey,TSelf})"/>
+    ///     Should be at least as big as <see cref="IHaveBoxedChildrenWithKeyExtensions.CountChildren{TSelf,TKey}(NexusMods.Paths.Trees.KeyedBox{TKey,TSelf})"/>
     /// </param>
     /// <param name="index">The current index in the array.</param>
     public static void GetValuesUnsafe<TKey, TSelf, TValue>(TSelf item, Span<TValue> buffer, ref int index)
@@ -378,4 +379,35 @@ public static class IHaveValueExtensionsForIHaveBoxedChildrenWithValue
             GetValuesUnsafe<TKey, TSelf, TValue>(pair.Value.Item, buffer, ref index);
         }
     }
+}
+
+/// <summary>
+///    Extensions for <see cref="IHaveValue{TValue}"/>
+/// </summary>
+[ExcludeFromCodeCoverage] // Wrapper
+// ReSharper disable once InconsistentNaming
+public static class IHaveValueExtensions
+{
+    /// <summary>
+    ///     Retrieves the value of the node.
+    /// </summary>
+    /// <param name="item">The keyed boxed node whose value is to be retrieved.</param>
+    /// <typeparam name="TSelf">The type of the child node.</typeparam>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <returns>The value of the node.</returns>
+    public static TValue Value<TSelf, TValue>(this KeyedBox<TValue, TSelf> item)
+        where TSelf : struct, IHaveValue<TValue>
+        where TValue : notnull
+        => item.Item.Value;
+
+    /// <summary>
+    ///     Retrieves the value of the node.
+    /// </summary>
+    /// <param name="item">The boxed node whose value is to be retrieved.</param>
+    /// <typeparam name="TSelf">The type of the child node.</typeparam>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <returns>The value of the node.</returns>
+    public static TValue Value<TSelf, TValue>(this Box<TSelf> item)
+        where TSelf : struct, IHaveValue<TValue>
+        => item.Item.Value;
 }

--- a/src/NexusMods.Paths/Trees/Traits/IHaveValue.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveValue.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using NexusMods.Paths.Trees.Traits.Interfaces;
-using Reloaded.Memory.Extensions;
 
 namespace NexusMods.Paths.Trees.Traits;
 
@@ -107,7 +106,7 @@ public static class IHaveValueExtensionsForIHaveBoxedChildren
     /// <returns>An array of all the values of the children of this node.</returns>
     public static TValue[] GetValues<TSelf, TValue>(this TSelf item)
         where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveValue<TValue> =>
-        item.GetChildItems<TSelf, TValue, ValueSelector<TSelf, TValue>>(new ValueSelector<TSelf, TValue>());
+        item.GetChildrenRecursive<TSelf, TValue, ValueSelector<TSelf, TValue>>();
 
     /// <summary>
     ///     Helper method to populate values recursively.
@@ -121,7 +120,7 @@ public static class IHaveValueExtensionsForIHaveBoxedChildren
     [ExcludeFromCodeCoverage]
     public static void GetValuesUnsafe<TSelf, TValue>(TSelf item, Span<TValue> buffer, ref int index)
         where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveValue<TValue> =>
-        item.GetChildItemsUnsafe(new ValueSelector<TSelf, TValue>(), buffer, ref index);
+        item.GetChildrenRecursiveUnsafe<TSelf, TValue, ValueSelector<TSelf, TValue>>(buffer, ref index);
 }
 
 /// <summary>
@@ -213,7 +212,7 @@ public static class IHaveValueExtensionsForIHaveObservableChildren
     /// <returns>An array of all the values of the children of this node.</returns>
     public static TValue[] GetValues<TSelf, TValue>(this TSelf item)
         where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveValue<TValue> =>
-        item.GetChildItems<TSelf, TValue, ValueSelector<TSelf, TValue>>(new ValueSelector<TSelf, TValue>());
+        item.GetChildrenRecursive<TSelf, TValue, ValueSelector<TSelf, TValue>>();
 
     /// <summary>
     ///     Helper method to populate values recursively.
@@ -227,7 +226,7 @@ public static class IHaveValueExtensionsForIHaveObservableChildren
     [ExcludeFromCodeCoverage]
     public static void GetValuesUnsafe<TSelf, TValue>(TSelf item, Span<TValue> buffer, ref int index)
         where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveValue<TValue> =>
-        item.GetChildItemsUnsafe(new ValueSelector<TSelf, TValue>(), buffer, ref index);
+        item.GetChildrenRecursiveUnsafe<TSelf, TValue, ValueSelector<TSelf, TValue>>(buffer, ref index);
 }
 
 /// <summary>
@@ -329,7 +328,7 @@ public static class IHaveValueExtensionsForIHaveBoxedChildrenWithKey
     public static TValue[] GetValues<TKey, TSelf, TValue>(this TSelf item)
         where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveValue<TValue>
         where TKey : notnull
-        => item.GetChildItems<TKey, TSelf, TValue, ValueSelector<TKey, TSelf, TValue>>(new ValueSelector<TKey, TSelf, TValue>());
+        => item.GetChildrenRecursive<TSelf, TKey, TValue, ValueSelector<TKey, TSelf, TValue>>();
 
     /// <summary>
     ///     Helper method to populate values recursively.
@@ -344,7 +343,7 @@ public static class IHaveValueExtensionsForIHaveBoxedChildrenWithKey
     public static void GetValuesUnsafe<TKey, TSelf, TValue>(TSelf item, Span<TValue> buffer, ref int index)
         where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveValue<TValue>
         where TKey : notnull
-        => item.GetChildItemsUnsafe<TKey, TSelf, TValue, ValueSelector<TKey, TSelf, TValue>>(new ValueSelector<TKey, TSelf, TValue>(), buffer, ref index);
+        => item.GetChildrenRecursiveUnsafe<TSelf, TKey, TValue, ValueSelector<TKey, TSelf, TValue>>(buffer, ref index);
 }
 
 /// <summary>
@@ -381,12 +380,12 @@ public static class IHaveValueExtensions
 internal struct ValueSelector<TSelf, TValue> : ISelector<TSelf, TValue>
     where TSelf : struct, IHaveValue<TValue>
 {
-    public TValue Select(TSelf item) => item.Value;
+    public static TValue Select(TSelf item) => item.Value;
 }
 
 internal struct ValueSelector<TKey, TSelf, TValue> : ISelector<TSelf, TValue>
     where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveValue<TValue>
     where TKey : notnull
 {
-    public TValue Select(TSelf item) => item.Value;
+    public static TValue Select(TSelf item) => item.Value;
 }

--- a/src/NexusMods.Paths/Trees/Traits/IHaveValue.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveValue.cs
@@ -308,6 +308,20 @@ public static class IHaveValueExtensions
     /// <typeparam name="TValue">The type of the value.</typeparam>
     /// <typeparam name="TKey">Type of key used.</typeparam>
     /// <returns>The value of the node.</returns>
+    public static TValue Value<TSelf, TKey, TValue>(this KeyValuePair<TKey, KeyedBox<TKey, TSelf>> item)
+        where TSelf : struct, IHaveValue<TValue>
+        where TValue : notnull
+        where TKey : notnull
+        => item.Value.Item.Value;
+
+    /// <summary>
+    ///     Retrieves the value of the node.
+    /// </summary>
+    /// <param name="item">The keyed boxed node whose value is to be retrieved.</param>
+    /// <typeparam name="TSelf">The type of the child node.</typeparam>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <typeparam name="TKey">Type of key used.</typeparam>
+    /// <returns>The value of the node.</returns>
     public static TValue Value<TSelf, TKey, TValue>(this KeyedBox<TKey, TSelf> item)
         where TSelf : struct, IHaveValue<TValue>
         where TValue : notnull

--- a/src/NexusMods.Paths/Trees/Traits/IHaveValue.cs
+++ b/src/NexusMods.Paths/Trees/Traits/IHaveValue.cs
@@ -43,18 +43,7 @@ public static class IHaveValueExtensionsForIHaveBoxedChildren
     /// <returns>An IEnumerable of all child values of the current node.</returns>
     public static IEnumerable<TValue> EnumerateValuesBfs<TSelf, TValue>(this TSelf item)
         where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveValue<TValue>
-    {
-        // First return all values of the immediate children
-        foreach (var child in item.Children)
-            yield return child.Item.Value;
-
-        // Then iterate over the immediate children and recursively enumerate their values
-        foreach (var child in item.Children)
-        {
-            foreach (var grandChildvalue in child.Item.EnumerateValuesBfs<TSelf, TValue>())
-                yield return grandChildvalue;
-        }
-    }
+        => item.EnumerateChildrenBfs<TSelf, TValue, BoxValueSelector<TSelf, TValue>>();
 
     /// <summary>
     ///     Enumerates all values of the child nodes of the current node in a depth-first manner.
@@ -76,15 +65,7 @@ public static class IHaveValueExtensionsForIHaveBoxedChildren
     /// <returns>An IEnumerable of all child values of the current node.</returns>
     public static IEnumerable<TValue> EnumerateValuesDfs<TSelf, TValue>(this TSelf item)
         where TSelf : struct, IHaveBoxedChildren<TSelf>, IHaveValue<TValue>
-    {
-        // Enumerate the value of each child and then recursively enumerate the values of its children
-        foreach (var child in item.Children)
-        {
-            yield return child.Item.Value;
-            foreach (var grandChildvalue in child.Item.EnumerateValuesDfs<TSelf, TValue>())
-                yield return grandChildvalue;
-        }
-    }
+        => item.EnumerateChildrenDfs<TSelf, TValue, BoxValueSelector<TSelf, TValue>>();
 
     /// <summary>
     ///     Recursively returns all the values of the children of this node.
@@ -149,18 +130,7 @@ public static class IHaveValueExtensionsForIHaveObservableChildren
     /// <returns>An IEnumerable of all child values of the current node.</returns>
     public static IEnumerable<TValue> EnumerateValuesBfs<TSelf, TValue>(this TSelf item)
         where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveValue<TValue>
-    {
-        // First return all values of the immediate children
-        foreach (var child in item.Children)
-            yield return child.Item.Value;
-
-        // Then iterate over the immediate children and recursively enumerate their values
-        foreach (var child in item.Children)
-        {
-            foreach (var grandChildvalue in child.Item.EnumerateValuesBfs<TSelf, TValue>())
-                yield return grandChildvalue;
-        }
-    }
+        => item.EnumerateChildrenBfs<TSelf, TValue, BoxValueSelector<TSelf, TValue>>();
 
     /// <summary>
     ///     Enumerates all values of the child nodes of the current node in a depth-first manner.
@@ -182,15 +152,7 @@ public static class IHaveValueExtensionsForIHaveObservableChildren
     /// <returns>An IEnumerable of all child values of the current node.</returns>
     public static IEnumerable<TValue> EnumerateValuesDfs<TSelf, TValue>(this TSelf item)
         where TSelf : struct, IHaveObservableChildren<TSelf>, IHaveValue<TValue>
-    {
-        // Enumerate the value of each child and then recursively enumerate the values of its children
-        foreach (var child in item.Children)
-        {
-            yield return child.Item.Value;
-            foreach (var grandChildvalue in child.Item.EnumerateValuesDfs<TSelf, TValue>())
-                yield return grandChildvalue;
-        }
-    }
+        => item.EnumerateChildrenDfs<TSelf, TValue, BoxValueSelector<TSelf, TValue>>();
 
     /// <summary>
     ///     Recursively returns all the values of the children of this node.
@@ -243,10 +205,10 @@ public static class IHaveValueExtensionsForIHaveBoxedChildrenWithKey
     /// <typeparam name="TKey">The type of the key.</typeparam>
     /// <typeparam name="TValue">The type of the value.</typeparam>
     /// <returns>An IEnumerable of all child values of the current node.</returns>
-    public static IEnumerable<TValue> EnumerateValuesBfs<TKey, TSelf, TValue>(this KeyedBox<TKey, TSelf> item)
-        where TSelf : struct, IHaveBoxedChildrenWithKey<TValue, TSelf>, IHaveValue<TValue>
+    public static IEnumerable<TValue> EnumerateValuesBfs<TSelf, TKey, TValue>(this KeyedBox<TKey, TSelf> item)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveValue<TValue>
         where TValue : notnull
-        where TKey : notnull => item.Item.EnumerateValuesBfs<TSelf, TValue>();
+        where TKey : notnull => item.Item.EnumerateValuesBfs<TSelf, TKey, TValue>();
 
     /// <summary>
     ///     Enumerates all values of the child nodes of the current node in a breadth-first manner.
@@ -254,22 +216,13 @@ public static class IHaveValueExtensionsForIHaveBoxedChildrenWithKey
     /// <param name="item">The node whose child values are to be enumerated.</param>
     /// <typeparam name="TSelf">The type of the child node.</typeparam>
     /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <typeparam name="TKey">The type of key.</typeparam>
     /// <returns>An IEnumerable of all child values of the current node.</returns>
-    public static IEnumerable<TValue> EnumerateValuesBfs<TSelf, TValue>(this TSelf item)
-        where TSelf : struct, IHaveBoxedChildrenWithKey<TValue, TSelf>, IHaveValue<TValue>
+    public static IEnumerable<TValue> EnumerateValuesBfs<TSelf, TKey, TValue>(this TSelf item)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveValue<TValue>
         where TValue : notnull
-    {
-        // First return all values of the immediate children
-        foreach (var child in item.Children)
-            yield return child.Value.Item.Value;
-
-        // Then iterate over the immediate children and recursively enumerate their values
-        foreach (var child in item.Children)
-        {
-            foreach (var grandChildvalue in child.Value.Item.EnumerateValuesBfs<TSelf, TValue>())
-                yield return grandChildvalue;
-        }
-    }
+        where TKey : notnull
+        => item.EnumerateChildrenBfs<TSelf, TKey, TValue, KeyValueValueSelector<TSelf, TKey, TValue>>();
 
     /// <summary>
     ///     Enumerates all values of the child nodes of the current node in a depth-first manner.
@@ -279,10 +232,10 @@ public static class IHaveValueExtensionsForIHaveBoxedChildrenWithKey
     /// <typeparam name="TValue">The type of the value.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
     /// <returns>An IEnumerable of all child values of the current node.</returns>
-    public static IEnumerable<TValue> EnumerateValuesDfs<TKey, TSelf, TValue>(this KeyedBox<TKey, TSelf> item)
-        where TSelf : struct, IHaveBoxedChildrenWithKey<TValue, TSelf>, IHaveValue<TValue>
+    public static IEnumerable<TValue> EnumerateValuesDfs<TSelf, TKey, TValue>(this KeyedBox<TKey, TSelf> item)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveValue<TValue>
         where TValue : notnull
-        where TKey : notnull => item.Item.EnumerateValuesDfs<TSelf, TValue>();
+        where TKey : notnull => item.Item.EnumerateValuesDfs<TSelf, TKey, TValue>();
 
     /// <summary>
     ///     Enumerates all values of the child nodes of the current node in a depth-first manner.
@@ -290,19 +243,13 @@ public static class IHaveValueExtensionsForIHaveBoxedChildrenWithKey
     /// <param name="item">The node whose child values are to be enumerated.</param>
     /// <typeparam name="TSelf">The type of the child node.</typeparam>
     /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <typeparam name="TKey">The type of key used.</typeparam>
     /// <returns>An IEnumerable of all child values of the current node.</returns>
-    public static IEnumerable<TValue> EnumerateValuesDfs<TSelf, TValue>(this TSelf item)
-        where TSelf : struct, IHaveBoxedChildrenWithKey<TValue, TSelf>, IHaveValue<TValue>
+    public static IEnumerable<TValue> EnumerateValuesDfs<TSelf, TKey, TValue>(this TSelf item)
+        where TSelf : struct, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveValue<TValue>
         where TValue : notnull
-    {
-        // Enumerate the value of each child and then recursively enumerate the values of its children
-        foreach (var child in item.Children)
-        {
-            yield return child.Value.Item.Value;
-            foreach (var grandChildvalue in child.Value.Item.EnumerateValuesDfs<TSelf, TValue>())
-                yield return grandChildvalue;
-        }
-    }
+        where TKey : notnull
+        => item.EnumerateChildrenDfs<TSelf, TKey, TValue, KeyValueValueSelector<TSelf, TKey, TValue>>();
 
     /// <summary>
     ///     Recursively returns all the values of the children of this node.
@@ -359,10 +306,12 @@ public static class IHaveValueExtensions
     /// <param name="item">The keyed boxed node whose value is to be retrieved.</param>
     /// <typeparam name="TSelf">The type of the child node.</typeparam>
     /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <typeparam name="TKey">Type of key used.</typeparam>
     /// <returns>The value of the node.</returns>
-    public static TValue Value<TSelf, TValue>(this KeyedBox<TValue, TSelf> item)
+    public static TValue Value<TSelf, TKey, TValue>(this KeyedBox<TKey, TSelf> item)
         where TSelf : struct, IHaveValue<TValue>
         where TValue : notnull
+        where TKey : notnull
         => item.Item.Value;
 
     /// <summary>
@@ -375,6 +324,19 @@ public static class IHaveValueExtensions
     public static TValue Value<TSelf, TValue>(this Box<TSelf> item)
         where TSelf : struct, IHaveValue<TValue>
         => item.Item.Value;
+}
+
+internal struct BoxValueSelector<TSelf, TValue> : ISelector<Box<TSelf>, TValue>
+    where TSelf : struct, IHaveValue<TValue>
+{
+    public static TValue Select(Box<TSelf> item) => item.Item.Value;
+}
+
+internal struct KeyValueValueSelector<TSelf, TKey, TValue> : ISelector<KeyValuePair<TKey, KeyedBox<TKey, TSelf>>, TValue>
+    where TSelf : struct, IHaveValue<TValue>
+    where TKey : notnull
+{
+    public static TValue Select(KeyValuePair<TKey, KeyedBox<TKey, TSelf>> item) => item.Value.Item.Value;
 }
 
 internal struct ValueSelector<TSelf, TValue> : ISelector<TSelf, TValue>

--- a/src/NexusMods.Paths/Trees/Traits/Interfaces/IFilter.cs
+++ b/src/NexusMods.Paths/Trees/Traits/Interfaces/IFilter.cs
@@ -11,6 +11,6 @@ public interface IFilter<T>
     /// </summary>
     /// <param name="item">The item to be checked.</param>
     /// <returns>True if the item should be returned, else false.</returns>
-    bool Match(T item);
+    static abstract bool Match(T item);
 }
 

--- a/src/NexusMods.Paths/Trees/Traits/Interfaces/IFilter.cs
+++ b/src/NexusMods.Paths/Trees/Traits/Interfaces/IFilter.cs
@@ -1,0 +1,16 @@
+namespace NexusMods.Paths.Trees.Traits.Interfaces;
+
+/// <summary>
+///     Represents a filter that can be applied to tree items.
+/// </summary>
+/// <typeparam name="T">Type to be filtered</typeparam>
+public interface IFilter<T>
+{
+    /// <summary>
+    ///     Checks if the item should be returned.
+    /// </summary>
+    /// <param name="item">The item to be checked.</param>
+    /// <returns>True if the item should be returned, else false.</returns>
+    bool Match(T item);
+}
+

--- a/src/NexusMods.Paths/Trees/Traits/Interfaces/ISelector.cs
+++ b/src/NexusMods.Paths/Trees/Traits/Interfaces/ISelector.cs
@@ -1,0 +1,16 @@
+namespace NexusMods.Paths.Trees.Traits.Interfaces;
+
+/// <summary>
+///     Represents an interface that selects an item from a given type denoted T.
+/// </summary>
+/// <typeparam name="T">Type to get the item from.</typeparam>
+/// <typeparam name="TResult">The returned item.</typeparam>
+public interface ISelector<T, TResult>
+{
+    /// <summary>
+    ///     Checks if the item should be returned.
+    /// </summary>
+    /// <param name="item">The parameter from which the item is to be returned.</param>
+    /// <returns>The returned item from the method.</returns>
+    TResult Select(T item);
+}

--- a/src/NexusMods.Paths/Trees/Traits/Interfaces/ISelector.cs
+++ b/src/NexusMods.Paths/Trees/Traits/Interfaces/ISelector.cs
@@ -12,5 +12,5 @@ public interface ISelector<T, TResult>
     /// </summary>
     /// <param name="item">The parameter from which the item is to be returned.</param>
     /// <returns>The returned item from the method.</returns>
-    TResult Select(T item);
+    static abstract TResult Select(T item);
 }

--- a/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildren/FilterAndSelectTests.cs
+++ b/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildren/FilterAndSelectTests.cs
@@ -1,0 +1,71 @@
+using NexusMods.Paths.Trees;
+using NexusMods.Paths.Trees.Traits;
+using NexusMods.Paths.Trees.Traits.Interfaces;
+
+namespace NexusMods.Paths.Tests.Trees.Interfaces.BoxedChildren;
+
+// ReSharper disable once InconsistentNaming
+public class FilterAndSelectTests
+{
+    [Fact]
+    public void GetChildItems_ShouldReturnAllValuesRecursively()
+    {
+        // Arrange
+        var grandChild1 = TestTree.Create(null, 3);
+        var grandChild2 = TestTree.Create(null, 4);
+        var child1 = TestTree.Create(new[] { grandChild1 }, 1);
+        var child2 = TestTree.Create(new[] { grandChild2 }, 2);
+        var root = TestTree.Create(new[] { child1, child2 });
+
+        // Act
+        var values = root.GetChildrenRecursive<TestTree, int, ValuesOverTwoFilter<TestTree>, ValueSelector<TestTree, int>>();
+
+        // Assert
+        values.Should().Equal(3, 4);
+    }
+
+    [Fact]
+    public void GetChildItemsUnsafe_ShouldReturnAllValuesRecursively()
+    {
+        // Arrange
+        var grandChild1 = TestTree.Create(null, 3);
+        var grandChild2 = TestTree.Create(null, 4);
+        var child1 = TestTree.Create(new[] { grandChild1 }, 1);
+        var child2 = TestTree.Create(new[] { grandChild2 }, 2);
+        var root = TestTree.Create(new[] { child1, child2 });
+
+        var buffer = new int[2];
+        var index = 0;
+
+        // Act
+        root.GetChildrenRecursiveUnsafe<TestTree, int, ValuesOverTwoFilter<TestTree>, ValueSelector<TestTree, int>>(buffer, ref index);
+
+        // Assert
+        buffer.Should().Equal(3, 4);
+    }
+
+    private struct TestTree : IHaveBoxedChildren<TestTree>, IHaveValue<int>
+    {
+        public Box<TestTree>[] Children { get; private init; }
+        public int Value { get; private init; }
+
+        public static Box<TestTree> Create(Box<TestTree>[]? children, int value = default)
+        {
+            return (Box<TestTree>)new TestTree()
+            {
+                Children = children ?? Array.Empty<Box<TestTree>>(),
+                Value = value
+            };
+        }
+    }
+
+    private struct ValuesOverTwoFilter<TSelf> : IFilter<TSelf> where TSelf : struct, IHaveValue<int>
+    {
+        public static bool Match(TSelf item) => item.Value > 2;
+    }
+
+    private struct ValueSelector<TSelf, TValue> : ISelector<TSelf, TValue> where TSelf : struct, IHaveValue<TValue>
+    {
+        public static TValue Select(TSelf item) => item.Value;
+    }
+}

--- a/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildren/FilterAndSelectTests.cs
+++ b/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildren/FilterAndSelectTests.cs
@@ -44,6 +44,40 @@ public class FilterAndSelectTests
         buffer.Should().Equal(3, 4);
     }
 
+    [Fact]
+    public void EnumerateChildrenDfs_WithFilterAndSelector_ShouldReturnTransformedValues()
+    {
+        // Arrange
+        var grandChild1 = TestTree.Create(null, 4);
+        var grandChild2 = TestTree.Create(null, 5);
+        var child1 = TestTree.Create(new[] { grandChild1 }, 3);
+        var child2 = TestTree.Create(new[] { grandChild2 }, 2);
+        var root = TestTree.Create(new[] { child1, child2 });
+
+        // Act
+        var transformedValues = root.EnumerateChildrenDfs<TestTree, int, ValueOverOneFilter<TestTree>, DoubleValueSelector<TestTree>>().ToList();
+
+        // Assert
+        transformedValues.Should().Equal(6, 8, 4, 10);
+    }
+
+    [Fact]
+    public void EnumerateChildrenBfs_WithFilterAndSelector_ShouldReturnTransformedValues()
+    {
+        // Arrange
+        var grandChild1 = TestTree.Create(null, 4);
+        var grandChild2 = TestTree.Create(null, 5);
+        var child1 = TestTree.Create(new[] { grandChild1 }, 3);
+        var child2 = TestTree.Create(new[] { grandChild2 }, 2);
+        var root = TestTree.Create(new[] { child1, child2 });
+
+        // Act
+        var transformedValues = root.EnumerateChildrenBfs<TestTree, int, ValueOverOneFilter<TestTree>, DoubleValueSelector<TestTree>>().ToList();
+
+        // Assert
+        transformedValues.Should().Equal(6, 4, 8, 10);
+    }
+
     private struct TestTree : IHaveBoxedChildren<TestTree>, IHaveValue<int>
     {
         public Box<TestTree>[] Children { get; private init; }
@@ -67,5 +101,15 @@ public class FilterAndSelectTests
     private struct ValueSelector<TSelf, TValue> : ISelector<TSelf, TValue> where TSelf : struct, IHaveValue<TValue>
     {
         public static TValue Select(TSelf item) => item.Value;
+    }
+
+    private struct ValueOverOneFilter<TSelf> : IFilter<Box<TSelf>> where TSelf : struct, IHaveValue<int>
+    {
+        public static bool Match(Box<TSelf> item) => item.Item.Value > 1;
+    }
+
+    private struct DoubleValueSelector<TSelf> : ISelector<Box<TSelf>, int> where TSelf : struct, IHaveValue<int>
+    {
+        public static int Select(Box<TSelf> item) => item.Item.Value * 2;
     }
 }

--- a/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildren/IHaveAFileOrDirectoryTests.cs
+++ b/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildren/IHaveAFileOrDirectoryTests.cs
@@ -37,6 +37,81 @@ public class IHaveAFileOrDirectoryTests
         directoryCount.Should().Be(1); // Only the root's child is a directory
     }
 
+    [Fact]
+    public void EnumerateFilesBfs_ShouldEnumerateAllFilesInBreadthFirstManner()
+    {
+        // Arrange
+        var leaf1 = TestTree.Create(true);
+        var leaf2 = TestTree.Create(true);
+        var directory = TestTree.Create(false, new[] { leaf1, leaf2 });
+        var root = TestTree.Create(false, new[] { directory });
+
+        // Act
+        var enumeratedFiles = root.EnumerateFilesBfs().ToList();
+
+        // Assert
+        enumeratedFiles.Count.Should().Be(2);
+        enumeratedFiles[0].Should().Be(leaf1);
+        enumeratedFiles[1].Should().Be(leaf2);
+    }
+
+    [Fact]
+    public void EnumerateDirectoriesBfs_ShouldEnumerateAllDirectoriesInBreadthFirstManner()
+    {
+        // Arrange
+        var leaf1 = TestTree.Create(true);
+        var directory1 = TestTree.Create(false, leaf1);
+        var directory2 = TestTree.Create(false);
+        var root = TestTree.Create(false, new[] { directory1, directory2 });
+
+        // Act
+        var enumeratedDirectories = root.EnumerateDirectoriesBfs().ToList();
+
+        // Assert
+        enumeratedDirectories.Count.Should().Be(2);
+        enumeratedDirectories[0].Should().Be(directory1);
+        enumeratedDirectories[1].Should().Be(directory2);
+    }
+
+    [Fact]
+    public void EnumerateFilesDfs_ShouldEnumerateAllFilesInDepthFirstManner()
+    {
+        // Arrange
+        var deepLeaf = TestTree.Create(true); // Deeper file
+        var shallowLeaf = TestTree.Create(true); // Shallow file
+        var subDirectory = TestTree.Create(false, new[] { deepLeaf });
+        var directory = TestTree.Create(false, new[] { subDirectory, shallowLeaf });
+        var root = TestTree.Create(false, new[] { directory });
+
+        // Act
+        var enumeratedFiles = root.EnumerateFilesDfs().ToList();
+
+        // Assert
+        enumeratedFiles.Count.Should().Be(2);
+        enumeratedFiles[0].Should().Be(deepLeaf); // Deeper file should come first
+        enumeratedFiles[1].Should().Be(shallowLeaf); // Followed by the shallow file
+    }
+
+    [Fact]
+    public void EnumerateDirectoriesDfs_ShouldEnumerateAllDirectoriesInDepthFirstManner()
+    {
+        // Arrange
+        var leafInDeepDirectory = TestTree.Create(true);
+        var deeperSubDirectory = TestTree.Create(false, new[] { leafInDeepDirectory }); // Nested deeper
+        var shallowDirectory = TestTree.Create(false); // Shallow directory
+        var deepDirectory = TestTree.Create(false, new[] { deeperSubDirectory }); // Contains deeperSubDirectory
+        var root = TestTree.Create(false, new[] { deepDirectory, shallowDirectory });
+
+        // Act
+        var enumeratedDirectories = root.EnumerateDirectoriesDfs().ToList();
+
+        // Assert
+        enumeratedDirectories.Count.Should().Be(3);
+        enumeratedDirectories[0].Should().Be(deepDirectory); // First, deepDirectory should come
+        enumeratedDirectories[1].Should().Be(deeperSubDirectory); // Then, deeperSubDirectory inside deepDirectory
+        enumeratedDirectories[2].Should().Be(shallowDirectory); // Finally, the shallowDirectory
+    }
+
     private struct TestTree : IHaveBoxedChildren<TestTree>, IHaveAFileOrDirectory
     {
         public Box<TestTree>[] Children { get; private init; }

--- a/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildren/IHaveAFileOrDirectoryTests.cs
+++ b/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildren/IHaveAFileOrDirectoryTests.cs
@@ -112,6 +112,78 @@ public class IHaveAFileOrDirectoryTests
         enumeratedDirectories[2].Should().Be(shallowDirectory); // Finally, the shallowDirectory
     }
 
+    [Fact]
+    public void GetFiles_ShouldReturnAllFiles()
+    {
+        // Arrange
+        var leaf1 = TestTree.Create(true);
+        var leaf2 = TestTree.Create(true);
+        var directory = TestTree.Create(false, new[] { leaf1, leaf2 });
+        var root = TestTree.Create(false, new[] { directory });
+
+        // Act
+        var files = root.GetFiles();
+
+        // Assert
+        files.Length.Should().Be(2);
+        files.Should().Contain(new[] { leaf1, leaf2 });
+    }
+
+    [Fact]
+    public void GetDirectories_ShouldReturnAllDirectories()
+    {
+        // Arrange
+        var leaf = TestTree.Create(true);
+        var directory = TestTree.Create(false, new[] { leaf });
+        var root = TestTree.Create(false, new[] { directory });
+
+        // Act
+        var directories = root.GetDirectories();
+
+        // Assert
+        directories.Length.Should().Be(1);
+        directories.Should().Contain(directory);
+    }
+
+    [Fact]
+    public void GetFilesUnsafe_ShouldReturnAllFiles()
+    {
+        // Arrange
+        var leaf1 = TestTree.Create(true);
+        var leaf2 = TestTree.Create(true);
+        var directory = TestTree.Create(false, new[] { leaf1, leaf2 });
+        var root = TestTree.Create(false, new[] { directory });
+
+        var filesSpan = new Box<TestTree>[2];
+        var index = 0;
+
+        // Act
+        root.GetFilesUnsafe(filesSpan, ref index);
+
+        // Assert
+        filesSpan.Length.Should().Be(2);
+        filesSpan.Should().Contain(new[] { leaf1, leaf2 });
+    }
+
+    [Fact]
+    public void GetDirectoriesUnsafe_ShouldReturnAllDirectories()
+    {
+        // Arrange
+        var leaf = TestTree.Create(true);
+        var directory = TestTree.Create(false, new[] { leaf });
+        var root = TestTree.Create(false, new[] { directory });
+
+        var directoriesSpan = new Box<TestTree>[1];
+        var index = 0;
+
+        // Act
+        root.GetDirectoriesUnsafe(directoriesSpan, ref index);
+
+        // Assert
+        directoriesSpan.Length.Should().Be(1);
+        directoriesSpan.Should().Contain(directory);
+    }
+
     private struct TestTree : IHaveBoxedChildren<TestTree>, IHaveAFileOrDirectory
     {
         public Box<TestTree>[] Children { get; private init; }

--- a/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildren/IHaveKeyParentMixinTests.cs
+++ b/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildren/IHaveKeyParentMixinTests.cs
@@ -71,6 +71,71 @@ public class IHaveKeyParentMixinTests
         foundNodes.Should().BeEmpty();
     }
 
+    [Fact]
+    public void FindSubPathRootsByKeyUpward_WithNestedPath_ShouldReturnAllMatchingNodes()
+    {
+        // Arrange
+        var deepChild1 = TestTree.Create(5);
+        var deepChild2 = TestTree.Create(5); // Same key as deepChild1
+        var grandChild1 = TestTree.Create(4, deepChild1);
+        var grandChild2 = TestTree.Create(4, deepChild2); // Same key as grandChild1
+        var child = TestTree.Create(new[] { grandChild1, grandChild2 }, 3);
+        var root = TestTree.Create(2, child);
+
+        // Act
+        var foundNodes = root.FindSubPathRootsByKeyUpward<TestTree, int>(new[] { 4, 5 });
+
+        // Assert
+        foundNodes.Count.Should().Be(2);
+        foundNodes.All(node => node.Item.Key == 4).Should().BeTrue();
+    }
+
+    [Fact]
+    public void FindSubPathRootsByKeyUpward_WithPartialMatchingPath_ShouldReturnPartialMatches()
+    {
+        // Arrange
+        var grandChild1 = TestTree.Create(4);
+        var grandChild2 = TestTree.Create(5);
+        var child1 = TestTree.Create(2, grandChild1);
+        var child2 = TestTree.Create(3, grandChild2);
+        var root = TestTree.Create(new[] { child1, child2 }, 1);
+
+        // Act
+        var foundNodes = root.FindSubPathRootsByKeyUpward<TestTree, int>(new[] { 4 });
+
+        // Assert
+        foundNodes.Count.Should().Be(1);
+        foundNodes[0].Item.Key.Should().Be(4);
+    }
+
+    [Fact]
+    public void FindSubPathRootsByKeyUpward_WithNonExistingPath_ShouldReturnEmpty()
+    {
+        // Arrange
+        var child = TestTree.Create(2);
+        var root = TestTree.Create(1, child);
+
+        // Act
+        var foundNodes = root.FindSubPathRootsByKeyUpward<TestTree, int>(new[] { 99 });
+
+        // Assert
+        foundNodes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FindSubPathRootsByKeyUpward_WithEmptyPath_ShouldReturnEmpty()
+    {
+        // Arrange
+        var child = TestTree.Create(null, 2);
+        var root = TestTree.Create(1, child);
+
+        // Act
+        var foundNodes = root.FindSubPathRootsByKeyUpward<TestTree, int>(Array.Empty<int>());
+
+        // Assert
+        foundNodes.Should().BeEmpty();
+    }
+
     private struct TestTree : IHaveBoxedChildren<TestTree>, IHaveKey<int>, IHaveParent<TestTree>
     {
         public Box<TestTree>? Parent { get; private set; }

--- a/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildren/IHaveParentTests.cs
+++ b/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildren/IHaveParentTests.cs
@@ -10,14 +10,14 @@ public class IHaveParentTests
     public void GetSiblings_WithNoParent_ReturnsHasNoParent()
     {
         var root = TestTree.Create();
-        root.Item.HasParent().Should().Be(false);
+        root.HasParent().Should().Be(false);
     }
 
     [Fact]
     public void GetSiblings_WithNoParent_ReturnsIsTreeRoot()
     {
         var root = TestTree.Create();
-        root.Item.IsTreeRoot().Should().Be(true);
+        root.IsTreeRoot().Should().Be(true);
     }
 
     [Fact]

--- a/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildrenWithKey/FilterAndSelectTests.cs
+++ b/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildrenWithKey/FilterAndSelectTests.cs
@@ -1,0 +1,71 @@
+using NexusMods.Paths.Trees;
+using NexusMods.Paths.Trees.Traits;
+using NexusMods.Paths.Trees.Traits.Interfaces;
+
+namespace NexusMods.Paths.Tests.Trees.Interfaces.BoxedChildrenWithKey;
+
+// ReSharper disable once InconsistentNaming
+public class FilterAndSelectTests
+{
+    [Fact]
+    public void GetChildItems_ShouldReturnAllValuesRecursively()
+    {
+        // Arrange
+        var grandChild1 = TestTree.Create(null, 3);
+        var grandChild2 = TestTree.Create(null, 4);
+        var child1 = TestTree.Create(new Dictionary<int, KeyedBox<int, TestTree>> { [1] = grandChild1 }, 1);
+        var child2 = TestTree.Create(new Dictionary<int, KeyedBox<int, TestTree>> { [2] = grandChild2 }, 2);
+        var root = TestTree.Create(new Dictionary<int, KeyedBox<int, TestTree>> { [1] = child1, [2] = child2 }, 0);
+
+        // Act
+        var values = root.GetChildrenRecursive<TestTree, int, int, ValuesOverTwoFilter<TestTree>, ValueSelector<TestTree, int>>();
+
+        // Assert
+        values.Should().Equal(3, 4);
+    }
+
+    [Fact]
+    public void GetChildItemsUnsafe_ShouldReturnAllValuesRecursively()
+    {
+        // Arrange
+        var grandChild1 = TestTree.Create(null, 3);
+        var grandChild2 = TestTree.Create(null, 4);
+        var child1 = TestTree.Create(new Dictionary<int, KeyedBox<int, TestTree>> { [1] = grandChild1 }, 1);
+        var child2 = TestTree.Create(new Dictionary<int, KeyedBox<int, TestTree>> { [2] = grandChild2 }, 2);
+        var root = TestTree.Create(new Dictionary<int, KeyedBox<int, TestTree>> { [1] = child1, [2] = child2 }, 0);
+
+        var buffer = new int[2];
+        var index = 0;
+
+        // Act
+        root.GetChildrenRecursiveUnsafe<TestTree, int, int, ValuesOverTwoFilter<TestTree>, ValueSelector<TestTree, int>>(buffer, ref index);
+
+        // Assert
+        buffer.Should().Equal(3, 4);
+    }
+
+    private struct TestTree : IHaveBoxedChildrenWithKey<int, TestTree>, IHaveValue<int>
+    {
+        public Dictionary<int, KeyedBox<int, TestTree>> Children { get; private init; }
+        public int Value { get; private init; }
+
+        public static KeyedBox<int, TestTree> Create(Dictionary<int, KeyedBox<int, TestTree>>? children, int value)
+        {
+            return (KeyedBox<int, TestTree>) new TestTree()
+            {
+                Children = children ?? new Dictionary<int, KeyedBox<int, TestTree>>(),
+                Value = value
+            };
+        }
+    }
+
+    private struct ValuesOverTwoFilter<TSelf> : IFilter<TSelf> where TSelf : struct, IHaveValue<int>
+    {
+        public static bool Match(TSelf item) => item.Value > 2;
+    }
+
+    private struct ValueSelector<TSelf, TValue> : ISelector<TSelf, TValue> where TSelf : struct, IHaveValue<TValue>
+    {
+        public static TValue Select(TSelf item) => item.Value;
+    }
+}

--- a/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildrenWithKey/IHaveFileOrDirectoryTests.cs
+++ b/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildrenWithKey/IHaveFileOrDirectoryTests.cs
@@ -18,7 +18,7 @@ public class IHaveFileOrDirectoryTests
             [1] = leaf1,
             [2] = leaf2
         });
-        KeyedBox<int, TestTree> root =  TestTree.Create(false, new Dict { [0] = directory });
+        var root =  TestTree.Create(false, new Dict { [0] = directory });
 
         // Act
         var fileCount = root.CountFiles();
@@ -35,13 +35,88 @@ public class IHaveFileOrDirectoryTests
         var leaf2 = TestTree.Create(true);
         var directory1 = TestTree.Create(false, new Dict { [1] = leaf1 });
         var directory2 = TestTree.Create(false, new Dict { [2] = leaf2 });
-        KeyedBox<int, TestTree> root = TestTree.Create(false, new Dict { [0] = directory1, [1] = directory2 });
+        var root = TestTree.Create(false, new Dict { [0] = directory1, [1] = directory2 });
 
         // Act
         var directoryCount = root.CountDirectories();
 
         // Assert
         directoryCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void EnumerateFilesBfs_ShouldEnumerateAllFilesInBreadthFirstManner()
+    {
+        // Arrange
+        var leaf1 = TestTree.Create(true);
+        var leaf2 = TestTree.Create(true);
+        var directory = TestTree.Create(false, new Dict { [1] = leaf1, [2] = leaf2 });
+        var root = TestTree.Create(false, new Dict { [0] = directory });
+
+        // Act
+        var enumeratedFiles = root.EnumerateFilesBfs().ToList();
+
+        // Assert
+        enumeratedFiles.Count.Should().Be(2);
+        enumeratedFiles.Select(kvp => kvp.Value).Should().Contain(leaf1);
+        enumeratedFiles.Select(kvp => kvp.Value).Should().Contain(leaf2);
+    }
+
+    [Fact]
+    public void EnumerateDirectoriesBfs_ShouldEnumerateAllDirectoriesInBreadthFirstManner()
+    {
+        // Arrange
+        var leaf1 = TestTree.Create(true);
+        var directory1 = TestTree.Create(false, new Dict { [1] = leaf1 });
+        var directory2 = TestTree.Create(false);
+        var root = TestTree.Create(false, new Dict { [0] = directory1, [1] = directory2 });
+
+        // Act
+        var enumeratedDirectories = root.EnumerateDirectoriesBfs().ToList();
+
+        // Assert
+        enumeratedDirectories.Count.Should().Be(2);
+        enumeratedDirectories.Select(kvp => kvp.Value).Should().Contain(directory1);
+        enumeratedDirectories.Select(kvp => kvp.Value).Should().Contain(directory2);
+    }
+
+    [Fact]
+    public void EnumerateFilesDfs_ShouldEnumerateAllFilesInDepthFirstManner()
+    {
+        // Arrange
+        var deepLeaf = TestTree.Create(true);
+        var shallowLeaf = TestTree.Create(true);
+        var subDirectory = TestTree.Create(false, new Dict { [0] = deepLeaf });
+        var directory = TestTree.Create(false, new Dict { [0] = subDirectory, [1] = shallowLeaf });
+        var root = TestTree.Create(false, new Dict { [0] = directory });
+
+        // Act
+        var enumeratedFiles = root.EnumerateFilesDfs().ToList();
+
+        // Assert
+        enumeratedFiles.Count.Should().Be(2);
+        enumeratedFiles.Select(kvp => kvp.Value).Should().Contain(deepLeaf);
+        enumeratedFiles.Select(kvp => kvp.Value).Should().Contain(shallowLeaf);
+    }
+
+    [Fact]
+    public void EnumerateDirectoriesDfs_ShouldEnumerateAllDirectoriesInDepthFirstManner()
+    {
+        // Arrange
+        var leafInDeepDirectory = TestTree.Create(true);
+        var deeperSubDirectory = TestTree.Create(false, new Dict { [0] = leafInDeepDirectory });
+        var shallowDirectory = TestTree.Create(false);
+        var deepDirectory = TestTree.Create(false, new Dict { [0] = deeperSubDirectory });
+        var root = TestTree.Create(false, new Dict { [0] = deepDirectory, [1] = shallowDirectory });
+
+        // Act
+        var enumeratedDirectories = root.EnumerateDirectoriesDfs().ToList();
+
+        // Assert
+        enumeratedDirectories.Count.Should().Be(3);
+        enumeratedDirectories.Select(kvp => kvp.Value).Should().Contain(deepDirectory);
+        enumeratedDirectories.Select(kvp => kvp.Value).Should().Contain(deeperSubDirectory);
+        enumeratedDirectories.Select(kvp => kvp.Value).Should().Contain(shallowDirectory);
     }
 
     internal struct TestTree : IHaveBoxedChildrenWithKey<int, TestTree>, IHaveAFileOrDirectory

--- a/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildrenWithKey/IHaveFileOrDirectoryTests.cs
+++ b/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildrenWithKey/IHaveFileOrDirectoryTests.cs
@@ -119,6 +119,78 @@ public class IHaveFileOrDirectoryTests
         enumeratedDirectories.Select(kvp => kvp.Value).Should().Contain(shallowDirectory);
     }
 
+    [Fact]
+    public void GetFiles_ShouldReturnAllFiles()
+    {
+        // Arrange
+        var leaf1 = TestTree.Create(true);
+        var leaf2 = TestTree.Create(true);
+        var directory = TestTree.Create(false, new Dict { [1] = leaf1, [2] = leaf2 });
+        var root = TestTree.Create(false, new Dict { [0] = directory });
+
+        // Act
+        var files = root.GetFiles();
+
+        // Assert
+        files.Length.Should().Be(2);
+        files.Should().Contain(new[] { leaf1, leaf2 });
+    }
+
+    [Fact]
+    public void GetDirectories_ShouldReturnAllDirectories()
+    {
+        // Arrange
+        var leaf = TestTree.Create(true);
+        var directory = TestTree.Create(false, new Dict { [1] = leaf });
+        var root = TestTree.Create(false, new Dict { [0] = directory });
+
+        // Act
+        var directories = root.GetDirectories();
+
+        // Assert
+        directories.Length.Should().Be(1);
+        directories.Should().Contain(directory);
+    }
+
+    [Fact]
+    public void GetFilesUnsafe_ShouldReturnAllFiles()
+    {
+        // Arrange
+        var leaf1 = TestTree.Create(true);
+        var leaf2 = TestTree.Create(true);
+        var directory = TestTree.Create(false, new Dict { [1] = leaf1, [2] = leaf2 });
+        var root = TestTree.Create(false, new Dict { [0] = directory });
+
+        var filesSpan = new KeyedBox<int, TestTree>[2];
+        var index = 0;
+
+        // Act
+        root.GetFilesUnsafe(filesSpan, ref index);
+
+        // Assert
+        filesSpan.Length.Should().Be(2);
+        filesSpan.Should().Contain(new[] { leaf1, leaf2 });
+    }
+
+    [Fact]
+    public void GetDirectoriesUnsafe_ShouldReturnAllDirectories()
+    {
+        // Arrange
+        var leaf = TestTree.Create(true);
+        var directory = TestTree.Create(false, new Dict { [1] = leaf });
+        var root = TestTree.Create(false, new Dict { [0] = directory });
+
+        var directoriesSpan = new KeyedBox<int, TestTree>[1];
+        var index = 0;
+
+        // Act
+        root.GetDirectoriesUnsafe(directoriesSpan, ref index);
+
+        // Assert
+        directoriesSpan.Length.Should().Be(1);
+        directoriesSpan.Should().Contain(directory);
+    }
+
     internal struct TestTree : IHaveBoxedChildrenWithKey<int, TestTree>, IHaveAFileOrDirectory
     {
         public Dict Children { get; private init; }

--- a/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildrenWithKey/IHaveKeyParentMinixTests.cs
+++ b/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildrenWithKey/IHaveKeyParentMinixTests.cs
@@ -53,7 +53,7 @@ public class IHaveKeyParentMixinTests
     {
         // Arrange
         var child = TestTree.Create(2);
-        KeyedBox<int, TestTree> root = TestTree.Create(1, new Dictionary<int, KeyedBox<int, TestTree>> { { 2, child } });
+        var root = TestTree.Create(1, new Dictionary<int, KeyedBox<int, TestTree>> { { 2, child } });
 
         // Act
         var foundNodes = root.FindSubPathsByKeyUpward(new[] { 99 });
@@ -67,10 +67,80 @@ public class IHaveKeyParentMixinTests
     {
         // Arrange
         var child = TestTree.Create(2);
-        KeyedBox<int, TestTree> root = TestTree.Create(child, 1);
+        var root = TestTree.Create(child, 1);
 
         // Act
         var foundNodes = root.FindSubPathsByKeyUpward(Array.Empty<int>());
+
+        // Assert
+        foundNodes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FindSubPathRootsByKeyUpward_WithNestedPath_ShouldReturnAllMatchingNodes()
+    {
+        // Arrange
+        var deepChild1 = TestTree.Create(5);
+        var grandChild1 = TestTree.Create(deepChild1, 4);
+        var child = TestTree.Create(3, new Dictionary<int, KeyedBox<int, TestTree>>
+        {
+            { 4, grandChild1 }
+        });
+        var root = TestTree.Create(child, 2);
+
+        // Act
+        var foundNodes = root.FindSubPathRootsByKeyUpward(new[] { 4, 5 });
+
+        // Assert
+        foundNodes.Count.Should().Be(1);
+        foundNodes.All(node => node.Item.Key == 4).Should().BeTrue();
+    }
+
+    [Fact]
+    public void FindSubPathRootsByKeyUpward_WithPartialMatchingPath_ShouldReturnPartialMatches()
+    {
+        // Arrange
+        var grandChild1 = TestTree.Create(4);
+        var grandChild2 = TestTree.Create(5);
+        var child1 = TestTree.Create(grandChild1, 2);
+        var child2 = TestTree.Create(grandChild2, 3);
+        var root = TestTree.Create(1, new Dictionary<int, KeyedBox<int, TestTree>>
+        {
+            { 2, child1 },
+            { 3, child2 }
+        });
+
+        // Act
+        var foundNodes = root.FindSubPathRootsByKeyUpward(new[] { 4 });
+
+        // Assert
+        foundNodes.Count.Should().Be(1);
+        foundNodes[0].Item.Key.Should().Be(4);
+    }
+
+    [Fact]
+    public void FindSubPathRootsByKeyUpward_WithNonExistingPath_ShouldReturnEmpty()
+    {
+        // Arrange
+        var child = TestTree.Create(2);
+        var root = TestTree.Create(1, new Dictionary<int, KeyedBox<int, TestTree>> { { 2, child } });
+
+        // Act
+        var foundNodes = root.FindSubPathRootsByKeyUpward(new[] { 99 });
+
+        // Assert
+        foundNodes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FindSubPathRootsByKeyUpward_WithEmptyPath_ShouldReturnEmpty()
+    {
+        // Arrange
+        var child = TestTree.Create(2);
+        var root = TestTree.Create(child, 1);
+
+        // Act
+        var foundNodes = root.FindSubPathRootsByKeyUpward(Array.Empty<int>());
 
         // Assert
         foundNodes.Should().BeEmpty();

--- a/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildrenWithKey/IHaveKeyTests.cs
+++ b/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildrenWithKey/IHaveKeyTests.cs
@@ -31,7 +31,7 @@ public class IHaveKeyTests
         var grandChild2 = TestTree.Create(4);
         var child1 = TestTree.Create(new Dictionary<int, KeyedBox<int, TestTree>> { { 3, grandChild1 } }, 1);
         var child2 = TestTree.Create(new Dictionary<int, KeyedBox<int, TestTree>> { { 4, grandChild2 } }, 2);
-        KeyedBox<int, TestTree> root = TestTree.Create(new Dictionary<int, KeyedBox<int, TestTree>> { { 1, child1 }, { 2, child2 } });
+        var root = TestTree.Create(new Dictionary<int, KeyedBox<int, TestTree>> { { 1, child1 }, { 2, child2 } });
 
         // Act
         var keys = root.EnumerateKeysDfs().ToArray();
@@ -54,7 +54,7 @@ public class IHaveKeyTests
         var keys = root.GetKeys();
 
         // Assert
-        keys.Should().Equal(1, 3, 2, 4);
+        keys.Should().Equal(1, 2, 3, 4);
     }
 
     [Fact]

--- a/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildrenWithKey/IHaveValueTests.cs
+++ b/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildrenWithKey/IHaveValueTests.cs
@@ -14,7 +14,7 @@ public class IHaveValueTests
         var grandChild2 = TestTree.Create(4);
         var child1 = TestTree.Create(new Dictionary<int, KeyedBox<int, TestTree>> { { 3, grandChild1 } }, 1);
         var child2 = TestTree.Create(new Dictionary<int, KeyedBox<int, TestTree>> { { 4, grandChild2 } }, 2);
-        KeyedBox<int, TestTree> root = TestTree.Create(new Dictionary<int, KeyedBox<int, TestTree>> { { 1, child1 }, { 2, child2 } }, 0);
+        var root = TestTree.Create(new Dictionary<int, KeyedBox<int, TestTree>> { { 1, child1 }, { 2, child2 } }, 0);
 
         // Act
         var values = root.EnumerateValuesBfs<int, TestTree, int>().ToArray();
@@ -31,7 +31,7 @@ public class IHaveValueTests
         var grandChild2 = TestTree.Create(4);
         var child1 = TestTree.Create(grandChild1, 1);
         var child2 = TestTree.Create(grandChild2, 2);
-        KeyedBox<int, TestTree> root = TestTree.Create(new Dictionary<int, KeyedBox<int, TestTree>> { { 1, child1 }, { 2, child2 } }, 0);
+        var root = TestTree.Create(new Dictionary<int, KeyedBox<int, TestTree>> { { 1, child1 }, { 2, child2 } }, 0);
 
         // Act
         var values = root.EnumerateValuesDfs<int, TestTree, int>().ToArray();
@@ -48,13 +48,13 @@ public class IHaveValueTests
         var grandChild2 = TestTree.Create(4);
         var child1 = TestTree.Create(grandChild1, 1);
         var child2 = TestTree.Create(grandChild2, 2);
-        KeyedBox<int, TestTree> root = TestTree.Create(new Dictionary<int, KeyedBox<int, TestTree>> { { 1, child1 }, { 2, child2 } }, 0);
+        var root = TestTree.Create(new Dictionary<int, KeyedBox<int, TestTree>> { { 1, child1 }, { 2, child2 } }, 0);
 
         // Act
         var values = root.GetValues<int, TestTree, int>();
 
         // Assert
-        values.Should().Equal(1, 3, 2, 4);
+        values.Should().Equal(1, 2, 3, 4);
     }
 
     private struct TestTree : IHaveBoxedChildrenWithKey<int, TestTree>, IHaveValue<int>

--- a/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildrenWithKey/IHaveValueTests.cs
+++ b/tests/NexusMods.Paths.Tests/Trees/Interfaces/BoxedChildrenWithKey/IHaveValueTests.cs
@@ -17,7 +17,7 @@ public class IHaveValueTests
         var root = TestTree.Create(new Dictionary<int, KeyedBox<int, TestTree>> { { 1, child1 }, { 2, child2 } }, 0);
 
         // Act
-        var values = root.EnumerateValuesBfs<int, TestTree, int>().ToArray();
+        var values = root.EnumerateValuesBfs<TestTree, int, int>().ToArray();
 
         // Assert
         values.Should().Equal(1, 2, 3, 4); // Breadth-first order
@@ -34,7 +34,7 @@ public class IHaveValueTests
         var root = TestTree.Create(new Dictionary<int, KeyedBox<int, TestTree>> { { 1, child1 }, { 2, child2 } }, 0);
 
         // Act
-        var values = root.EnumerateValuesDfs<int, TestTree, int>().ToArray();
+        var values = root.EnumerateValuesDfs<TestTree, int, int>().ToArray();
 
         // Assert
         values.Should().Equal(1, 3, 2, 4); // Depth-first order

--- a/tests/NexusMods.Paths.Tests/Trees/Interfaces/IHaveBoxedChildrenWithKeyTests.cs
+++ b/tests/NexusMods.Paths.Tests/Trees/Interfaces/IHaveBoxedChildrenWithKeyTests.cs
@@ -107,7 +107,7 @@ public class IHaveBoxedChildrenWithKeyTests
         // Arrange
         var grandChild = TestTree.Create();
         var child = TestTree.Create(new() { [1] = grandChild });
-        KeyedBox<int, TestTree> root = TestTree.Create(new() { [0] = child });
+        var root = TestTree.Create(new() { [0] = child });
 
         // Act
         var count = root.CountChildren();

--- a/tests/NexusMods.Paths.Tests/Trees/Interfaces/IHaveParentWithKeyTests.cs
+++ b/tests/NexusMods.Paths.Tests/Trees/Interfaces/IHaveParentWithKeyTests.cs
@@ -7,7 +7,7 @@ namespace NexusMods.Paths.Tests.Trees.Interfaces;
 public class IHaveParentWithKeyTests
 {
     [Fact]
-    public void FindByKeysUpward_WithCorrectSequence_ShouldReturnCorrectNode()
+    public void FindByKeyUpward_WithCorrectSequence_ShouldReturnCorrectNode()
     {
         // Arrange
         var root = TestTree.Create(1);
@@ -17,15 +17,67 @@ public class IHaveParentWithKeyTests
         root.Item.Children = new[] { child2 };
 
         // Act
-        var foundNode = grandChild.FindByKeysUpward<TestTree, int>(new[] { 1, 2, 3 });
+        var foundNode = grandChild.FindByKeyUpward<TestTree, int>(new[] { 1, 2, 3 });
 
         // Assert
         foundNode!.Should().NotBeNull();
-        foundNode!.Value.Key.Should().Be(3);
+        foundNode!.Item.Key.Should().Be(3);
     }
 
     [Fact]
-    public void FindByKeysUpward_WithIncorrectSequence_ShouldReturnNull()
+    public void FindRootByKeyUpward_WithCorrectSequence_ShouldReturnCorrectNode()
+    {
+        // Arrange
+        var root = TestTree.Create(1);
+        var child2 = TestTree.Create(2, root);
+        var grandChild = TestTree.Create(3, child2);
+        child2.Item.Children = new[] { grandChild };
+        root.Item.Children = new[] { child2 };
+
+        // Act
+        var foundNode = grandChild.FindRootByKeyUpward<TestTree, int>(new[] { 1, 2, 3 });
+
+        // Assert
+        foundNode!.Should().NotBeNull();
+        foundNode!.Item.Key.Should().Be(1);
+    }
+
+    [Fact]
+    public void FindRootByKeyUpward_WithSequenceLongerThanTree_ShouldBeNull()
+    {
+        // Arrange
+        var root = TestTree.Create(1);
+        var child2 = TestTree.Create(2, root);
+        var grandChild = TestTree.Create(3, child2);
+        child2.Item.Children = new[] { grandChild };
+        root.Item.Children = new[] { child2 };
+
+        // Act
+        var foundNode = grandChild.FindRootByKeyUpward<TestTree, int>(new[] { 0, 1, 2, 3 });
+
+        // Assert
+        foundNode!.Should().BeNull();
+    }
+
+    [Fact]
+    public void FindRootByKeyUpward_WithEmptyKeys_ShouldBeNull()
+    {
+        // Arrange
+        var root = TestTree.Create(1);
+        var child2 = TestTree.Create(2, root);
+        var grandChild = TestTree.Create(3, child2);
+        child2.Item.Children = new[] { grandChild };
+        root.Item.Children = new[] { child2 };
+
+        // Act
+        var foundNode = grandChild.FindRootByKeyUpward<TestTree, int>(Array.Empty<int>());
+
+        // Assert
+        foundNode!.Should().BeNull();
+    }
+
+    [Fact]
+    public void FindByKeyUpward_WithIncorrectSequence_ShouldReturnNull()
     {
         // Arrange
         var root = new Box<TestTree>();
@@ -36,14 +88,32 @@ public class IHaveParentWithKeyTests
         root.Item.Children = new[] { child1, child2 };
 
         // Act
-        var foundNode = grandChild.FindByKeysUpward<TestTree, int>(new[] { 3, 2, 99 });
+        var foundNode = grandChild.FindByKeyUpward<TestTree, int>(new[] { 3, 2, 99 });
 
         // Assert
         foundNode!.Should().BeNull();
     }
 
     [Fact]
-    public void FindByKeysUpward_WithPartialSequence_ShouldReturnResult()
+    public void FindRootByKeyUpward_WithIncorrectSequence_ShouldReturnNull()
+    {
+        // Arrange
+        var root = new Box<TestTree>();
+        var child1 = TestTree.Create(1, root);
+        var child2 = TestTree.Create(2, root);
+        var grandChild = TestTree.Create(3, child2);
+        child2.Item.Children = new[] { grandChild };
+        root.Item.Children = new[] { child1, child2 };
+
+        // Act
+        var foundNode = grandChild.FindRootByKeyUpward<TestTree, int>(new[] { 3, 2, 99 });
+
+        // Assert
+        foundNode!.Should().BeNull();
+    }
+
+    [Fact]
+    public void FindByKeyUpward_WithPartialSequence_ShouldReturnResult()
     {
         // Arrange
         var root = TestTree.Create(0);
@@ -54,11 +124,30 @@ public class IHaveParentWithKeyTests
         root.Item.Children = new[] { child1, child2 };
 
         // Act
-        var foundNode = grandChild.FindByKeysUpward<TestTree, int>(new[] { 2, 3 });
+        var foundNode = grandChild.FindByKeyUpward<TestTree, int>(new[] { 2, 3 });
 
         // Assert
         foundNode!.Should().NotBeNull();
-        foundNode!.Value.Key.Should().Be(3);
+        foundNode!.Item.Key.Should().Be(3);
+    }
+
+    [Fact]
+    public void FindRootByKeyUpward_WithPartialSequence_ShouldReturnResult()
+    {
+        // Arrange
+        var root = TestTree.Create(0);
+        var child1 = TestTree.Create(1, root);
+        var child2 = TestTree.Create(2, root);
+        var grandChild = TestTree.Create(3, child2);
+        child2.Item.Children = new[] { grandChild };
+        root.Item.Children = new[] { child1, child2 };
+
+        // Act
+        var foundNode = grandChild.FindRootByKeyUpward<TestTree, int>(new[] { 2, 3 });
+
+        // Assert
+        foundNode!.Should().NotBeNull();
+        foundNode!.Item.Key.Should().Be(2);
     }
 
     private struct TestTree : IHaveBoxedChildren<TestTree>, IHaveParent<TestTree>, IHaveKey<int>, IEquatable<TestTree>

--- a/tests/NexusMods.Paths.Tests/Trees/Interfaces/ObservableChildren/FilterAndSelectTests.cs
+++ b/tests/NexusMods.Paths.Tests/Trees/Interfaces/ObservableChildren/FilterAndSelectTests.cs
@@ -1,0 +1,72 @@
+using System.Collections.ObjectModel;
+using NexusMods.Paths.Trees;
+using NexusMods.Paths.Trees.Traits;
+using NexusMods.Paths.Trees.Traits.Interfaces;
+
+namespace NexusMods.Paths.Tests.Trees.Interfaces.ObservableChildren;
+
+// ReSharper disable once InconsistentNaming
+public class FilterAndSelectTests
+{
+    [Fact]
+    public void GetChildItems_ShouldReturnAllValuesRecursively()
+    {
+        // Arrange
+        var grandChild1 = TestTree.Create(null, 3);
+        var grandChild2 = TestTree.Create(null, 4);
+        var child1 = TestTree.Create(new ObservableCollection<Box<TestTree>> { grandChild1 }, 1);
+        var child2 = TestTree.Create(new ObservableCollection<Box<TestTree>> { grandChild2 }, 2);
+        var root = TestTree.Create(new ObservableCollection<Box<TestTree>> { child1, child2 });
+
+        // Act
+        var values = root.GetChildrenRecursive<TestTree, int, ValuesOverTwoFilter<TestTree>, ValueSelector<TestTree, int>>();
+
+        // Assert
+        values.Should().Equal(3, 4);
+    }
+
+    [Fact]
+    public void GetChildItemsUnsafe_ShouldReturnAllValuesRecursively()
+    {
+        // Arrange
+        var grandChild1 = TestTree.Create(null, 3);
+        var grandChild2 = TestTree.Create(null, 4);
+        var child1 = TestTree.Create(new ObservableCollection<Box<TestTree>> { grandChild1 }, 1);
+        var child2 = TestTree.Create(new ObservableCollection<Box<TestTree>> { grandChild2 }, 2);
+        var root = TestTree.Create(new ObservableCollection<Box<TestTree>> { child1, child2 });
+
+        var buffer = new int[2];
+        var index = 0;
+
+        // Act
+        root.GetChildrenRecursiveUnsafe<TestTree, int, ValuesOverTwoFilter<TestTree>, ValueSelector<TestTree, int>>(buffer, ref index);
+
+        // Assert
+        buffer.Should().Equal(3, 4);
+    }
+
+    private struct TestTree : IHaveObservableChildren<TestTree>, IHaveValue<int>
+    {
+        public ObservableCollection<Box<TestTree>> Children { get; private init; }
+        public int Value { get; private init; }
+
+        public static Box<TestTree> Create(ObservableCollection<Box<TestTree>>? children, int value = default)
+        {
+            return (Box<TestTree>)new TestTree()
+            {
+                Children = children ?? new ObservableCollection<Box<TestTree>>(),
+                Value = value
+            };
+        }
+    }
+
+    private struct ValuesOverTwoFilter<TSelf> : IFilter<TSelf> where TSelf : struct, IHaveValue<int>
+    {
+        public static bool Match(TSelf item) => item.Value > 2;
+    }
+
+    private struct ValueSelector<TSelf, TValue> : ISelector<TSelf, TValue> where TSelf : struct, IHaveValue<TValue>
+    {
+        public static TValue Select(TSelf item) => item.Value;
+    }
+}

--- a/tests/NexusMods.Paths.Tests/Trees/Interfaces/ObservableChildren/IHaveAFileOrDirectoryTests.cs
+++ b/tests/NexusMods.Paths.Tests/Trees/Interfaces/ObservableChildren/IHaveAFileOrDirectoryTests.cs
@@ -38,6 +38,81 @@ public class IHaveAFileOrDirectoryTests
         directoryCount.Should().Be(1); // Only the root's child is a directory
     }
 
+    [Fact]
+    public void EnumerateFilesBfs_ShouldEnumerateAllFilesInBreadthFirstManner()
+    {
+        // Arrange
+        var leaf1 = TestTree.Create(true);
+        var leaf2 = TestTree.Create(true);
+        var directory = TestTree.Create(false, new ObservableCollection<Box<TestTree>> { leaf1, leaf2 });
+        var root = TestTree.Create(false, new ObservableCollection<Box<TestTree>> { directory });
+
+        // Act
+        var enumeratedFiles = root.EnumerateFilesBfs().ToList();
+
+        // Assert
+        enumeratedFiles.Count.Should().Be(2);
+        enumeratedFiles[0].Should().Be(leaf1);
+        enumeratedFiles[1].Should().Be(leaf2);
+    }
+
+    [Fact]
+    public void EnumerateDirectoriesBfs_ShouldEnumerateAllDirectoriesInBreadthFirstManner()
+    {
+        // Arrange
+        var leaf1 = TestTree.Create(true);
+        var directory1 = TestTree.Create(false, leaf1);
+        var directory2 = TestTree.Create(false);
+        var root = TestTree.Create(false, new ObservableCollection<Box<TestTree>> { directory1, directory2 });
+
+        // Act
+        var enumeratedDirectories = root.EnumerateDirectoriesBfs().ToList();
+
+        // Assert
+        enumeratedDirectories.Count.Should().Be(2);
+        enumeratedDirectories[0].Should().Be(directory1);
+        enumeratedDirectories[1].Should().Be(directory2);
+    }
+
+    [Fact]
+    public void EnumerateFilesDfs_ShouldEnumerateAllFilesInDepthFirstManner()
+    {
+        // Arrange
+        var deepLeaf = TestTree.Create(true); // Deeper file
+        var shallowLeaf = TestTree.Create(true); // Shallow file
+        var subDirectory = TestTree.Create(false, new ObservableCollection<Box<TestTree>> { deepLeaf });
+        var directory = TestTree.Create(false, new ObservableCollection<Box<TestTree>> { subDirectory, shallowLeaf });
+        var root = TestTree.Create(false, new ObservableCollection<Box<TestTree>> { directory });
+
+        // Act
+        var enumeratedFiles = root.EnumerateFilesDfs().ToList();
+
+        // Assert
+        enumeratedFiles.Count.Should().Be(2);
+        enumeratedFiles[0].Should().Be(deepLeaf); // Deeper file should come first
+        enumeratedFiles[1].Should().Be(shallowLeaf); // Followed by the shallow file
+    }
+
+    [Fact]
+    public void EnumerateDirectoriesDfs_ShouldEnumerateAllDirectoriesInDepthFirstManner()
+    {
+        // Arrange
+        var leafInDeepDirectory = TestTree.Create(true);
+        var deeperSubDirectory = TestTree.Create(false, new ObservableCollection<Box<TestTree>> { leafInDeepDirectory }); // Nested deeper
+        var shallowDirectory = TestTree.Create(false); // Shallow directory
+        var deepDirectory = TestTree.Create(false, new ObservableCollection<Box<TestTree>> { deeperSubDirectory }); // Contains deeperSubDirectory
+        var root = TestTree.Create(false, new ObservableCollection<Box<TestTree>> { deepDirectory, shallowDirectory });
+
+        // Act
+        var enumeratedDirectories = root.EnumerateDirectoriesDfs().ToList();
+
+        // Assert
+        enumeratedDirectories.Count.Should().Be(3);
+        enumeratedDirectories[0].Should().Be(deepDirectory); // First, deepDirectory should come
+        enumeratedDirectories[1].Should().Be(deeperSubDirectory); // Then, deeperSubDirectory inside deepDirectory
+        enumeratedDirectories[2].Should().Be(shallowDirectory); // Finally, the shallowDirectory
+    }
+
     private struct TestTree : IHaveObservableChildren<TestTree>, IHaveAFileOrDirectory
     {
         public ObservableCollection<Box<TestTree>> Children { get; private init; }

--- a/tests/NexusMods.Paths.Tests/Trees/Interfaces/ObservableChildren/IHaveAFileOrDirectoryTests.cs
+++ b/tests/NexusMods.Paths.Tests/Trees/Interfaces/ObservableChildren/IHaveAFileOrDirectoryTests.cs
@@ -113,6 +113,78 @@ public class IHaveAFileOrDirectoryTests
         enumeratedDirectories[2].Should().Be(shallowDirectory); // Finally, the shallowDirectory
     }
 
+    [Fact]
+    public void GetFiles_ShouldReturnAllFiles()
+    {
+        // Arrange
+        var leaf1 = TestTree.Create(true);
+        var leaf2 = TestTree.Create(true);
+        var directory = TestTree.Create(false, new ObservableCollection<Box<TestTree>> { leaf1, leaf2 });
+        var root = TestTree.Create(false, new ObservableCollection<Box<TestTree>> { directory });
+
+        // Act
+        var files = root.GetFiles();
+
+        // Assert
+        files.Length.Should().Be(2);
+        files.Should().Contain(new[] { leaf1, leaf2 });
+    }
+
+    [Fact]
+    public void GetDirectories_ShouldReturnAllDirectories()
+    {
+        // Arrange
+        var leaf = TestTree.Create(true);
+        var directory = TestTree.Create(false, new ObservableCollection<Box<TestTree>> { leaf });
+        var root = TestTree.Create(false, new ObservableCollection<Box<TestTree>> { directory });
+
+        // Act
+        var directories = root.GetDirectories();
+
+        // Assert
+        directories.Length.Should().Be(1);
+        directories.Should().Contain(directory);
+    }
+
+    [Fact]
+    public void GetFilesUnsafe_ShouldReturnAllFiles()
+    {
+        // Arrange
+        var leaf1 = TestTree.Create(true);
+        var leaf2 = TestTree.Create(true);
+        var directory = TestTree.Create(false, new ObservableCollection<Box<TestTree>> { leaf1, leaf2 });
+        var root = TestTree.Create(false, new ObservableCollection<Box<TestTree>> { directory });
+
+        var filesSpan = new Box<TestTree>[2];
+        var index = 0;
+
+        // Act
+        root.GetFilesUnsafe(filesSpan, ref index);
+
+        // Assert
+        filesSpan.Length.Should().Be(2);
+        filesSpan.Should().Contain(new[] { leaf1, leaf2 });
+    }
+
+    [Fact]
+    public void GetDirectoriesUnsafe_ShouldReturnAllDirectories()
+    {
+        // Arrange
+        var leaf = TestTree.Create(true);
+        var directory = TestTree.Create(false, new ObservableCollection<Box<TestTree>> { leaf });
+        var root = TestTree.Create(false, new ObservableCollection<Box<TestTree>> { directory });
+
+        var directoriesSpan = new Box<TestTree>[1];
+        var index = 0;
+
+        // Act
+        root.GetDirectoriesUnsafe(directoriesSpan, ref index);
+
+        // Assert
+        directoriesSpan.Length.Should().Be(1);
+        directoriesSpan.Should().Contain(directory);
+    }
+
     private struct TestTree : IHaveObservableChildren<TestTree>, IHaveAFileOrDirectory
     {
         public ObservableCollection<Box<TestTree>> Children { get; private init; }

--- a/tests/NexusMods.Paths.Tests/Trees/Interfaces/ObservableChildren/IHaveKeyParentMixinTests.cs
+++ b/tests/NexusMods.Paths.Tests/Trees/Interfaces/ObservableChildren/IHaveKeyParentMixinTests.cs
@@ -72,6 +72,71 @@ public class IHaveKeyParentMixinTests
         foundNodes.Should().BeEmpty();
     }
 
+    [Fact]
+    public void FindSubPathRootsByKeyUpward_WithNestedPath_ShouldReturnAllMatchingNodes()
+    {
+        // Arrange
+        var deepChild1 = TestTree.Create(5);
+        var deepChild2 = TestTree.Create(5); // Same key as deepChild1
+        var grandChild1 = TestTree.Create(4, deepChild1);
+        var grandChild2 = TestTree.Create(4, deepChild2); // Same key as grandChild1
+        var child = TestTree.Create(new ObservableCollection<Box<TestTree>> { grandChild1, grandChild2 }, 3);
+        var root = TestTree.Create(2, child);
+
+        // Act
+        var foundNodes = root.FindSubPathRootsByKeyUpward<TestTree, int>(new[] { 4, 5 });
+
+        // Assert
+        foundNodes.Count.Should().Be(2);
+        foundNodes.All(node => node.Item.Key == 4).Should().BeTrue();
+    }
+
+    [Fact]
+    public void FindSubPathRootsByKeyUpward_WithPartialMatchingPath_ShouldReturnPartialMatches()
+    {
+        // Arrange
+        var grandChild1 = TestTree.Create(4);
+        var grandChild2 = TestTree.Create(5);
+        var child1 = TestTree.Create(2, grandChild1);
+        var child2 = TestTree.Create(3, grandChild2);
+        var root = TestTree.Create(new ObservableCollection<Box<TestTree>> { child1, child2 }, 1);
+
+        // Act
+        var foundNodes = root.FindSubPathRootsByKeyUpward<TestTree, int>(new[] { 4 });
+
+        // Assert
+        foundNodes.Count.Should().Be(1);
+        foundNodes[0].Item.Key.Should().Be(4);
+    }
+
+    [Fact]
+    public void FindSubPathRootsByKeyUpward_WithNonExistingPath_ShouldReturnEmpty()
+    {
+        // Arrange
+        var child = TestTree.Create(2);
+        var root = TestTree.Create(1, child);
+
+        // Act
+        var foundNodes = root.FindSubPathRootsByKeyUpward<TestTree, int>(new[] { 99 });
+
+        // Assert
+        foundNodes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FindSubPathRootsByKeyUpward_WithEmptyPath_ShouldReturnEmpty()
+    {
+        // Arrange
+        var child = TestTree.Create(null, 2);
+        var root = TestTree.Create(1, child);
+
+        // Act
+        var foundNodes = root.FindSubPathRootsByKeyUpward<TestTree, int>(Array.Empty<int>());
+
+        // Assert
+        foundNodes.Should().BeEmpty();
+    }
+
     private struct TestTree : IHaveObservableChildren<TestTree>, IHaveKey<int>, IHaveParent<TestTree>
     {
         public Box<TestTree>? Parent { get; private set; }

--- a/tests/NexusMods.Paths.Tests/Trees/Interfaces/ObservableChildren/IHaveParentTests.cs
+++ b/tests/NexusMods.Paths.Tests/Trees/Interfaces/ObservableChildren/IHaveParentTests.cs
@@ -11,14 +11,14 @@ public class IHaveParentTests
     public void GetSiblings_WithNoParent_ReturnsHasNoParent()
     {
         var root = TestTree.Create();
-        root.Item.HasParent().Should().Be(false);
+        root.HasParent().Should().Be(false);
     }
 
     [Fact]
     public void GetSiblings_WithNoParent_ReturnsIsTreeRoot()
     {
         var root = TestTree.Create();
-        root.Item.IsTreeRoot().Should().Be(true);
+        root.IsTreeRoot().Should().Be(true);
     }
 
     [Fact]


### PR DESCRIPTION
# About

I didn't know what to call this, so I figured `Trees 2.0` will probably do the trick.

This PR contains a significant expansion to our current `Trait Driven Tree System`, with the hope of making code just a bit more modular, and easier to use in general.

Required by:
- https://github.com/Nexus-Mods/NexusMods.App/issues/795

# Changes

## Introduced Modifiers

Note: Read the docs for more details, this is a simplified version.

Modifiers are mostly used internally inside the library to provide specialized zero cost functionality without repeating code.
For example, `GetFiles`, `GetDirectories` method(s) use `IFilter` under the hood.

| Modifier    | Description                             |
|-------------|-----------------------------------------|
| `IFilter`   | Filters which items should be returned. |
| `ISelector` | Allows you to select a sub-item.        |

Modifiers are intended to be used in 'flattening' operations throughout the library, i.e. those that convert
the tree into linear sequences such as Enumerators and Spans/Arrays. With modifiers you get the exact same code as if the you were to manually hand craft the specialized code.

***Modifiers are not a replacement for LINQ***, they're there to maximize code reuse (mostly) internally and provide
accelerated operations in common cases where normally multiple Linq operations would be needed (e.g. `Filter+Select`), to achieve the zero overhead promise.

### Using A Modifier

```csharp
internal struct FileFilter<TSelf> : IFilter<TSelf> where TSelf : struct, IHaveAFileOrDirectory
{
    public static bool Match(TSelf item) => item.IsFile;
}
```

And when method has a generic with `where IFilter<T>` constraint, just specify `FileFilter<TSelf>` as generic parameter.

## Improved Code Reuse

Existing implementations of methods, for example:
- `IHaveValueExtensions.EnumerateValuesBfs`
- `IHaveValueExtensions.EnumerateValuesDfs` 
- `IHaveValueExtensions.GetValues`
- `IHaveKeyExtensions.EnumerateValuesBfs`
- `IHaveKeyExtensions.EnumerateValuesDfs`  
- `IHaveKeyExtensions.GetKeys` 
- `IHaveAFileOrDirectoryExtensions.EnumerateFilesBfs` 
- `IHaveAFileOrDirectoryExtensions.EnumerateFilesDfs` 
- `IHaveAFileOrDirectoryExtensions.EnumerateDirectoriesBfs` 
- `IHaveAFileOrDirectoryExtensions.EnumerateDirectoriesDfs`
-  etc.

now use the new underlying implementations powered by `Modifiers`. 

## New APIs

| Method                          | Description                                                                   | Required Traits                   |
|---------------------------------|-------------------------------------------------------------------------------|-----------------------------------|
| `CountChildren`+F               | Counts the total number of child nodes under this node.                       |                                   |
| `EnumerateChildrenBfs`+FS        | Enumerates children of this node Breadth First.                               |                                   |
| `EnumerateChildrenDfs`+FS        | Enumerates children of this node using Depth First.                           |                                   |
| `EnumerateDirectoriesBfs`       | Enumerates all children that are directories (Breadth First).                 | `IHaveAFileOrDirectory`           |
| `EnumerateDirectoriesDfs`       | Enumerates all children that are directories (Depth First).                   | `IHaveAFileOrDirectory`           |
| `EnumerateFilesBfs`             | Enumerates all children that are files (Breadth First).                       | `IHaveAFileOrDirectory`           |
| `EnumerateFilesDfs`             | Enumerates all children that are files (Depth First).                         | `IHaveAFileOrDirectory`           |
| `GetChildrenRecursive`+FS       | Retrieves all children of this node (flattened).                              |                                   |
| `GetChildrenRecursiveUnsafe`+FS | Retrieves all children of this node (no bound checks).                        |                                   |
| `GetDirectories`                | Retrieves all children of this node that are directories (flattened).         | `IHaveAFileOrDirectory`           |
| `GetDirectoriesUnsafe`          | Retrieves all children of this node that are directories (no bound checks).   | `IHaveAFileOrDirectory`           |
| `GetFiles`                      | Retrieves all children of this node that are files (flattened).               | `IHaveAFileOrDirectory`           |
| `GetFilesUnsafe`                | Retrieves all children of this node that are files (no bound checks).         | `IHaveAFileOrDirectory`           |

Modifier reference:

| Modifier | Description     |
|----------|-----------------|
| +F       | Has `IFilter`   |
| +S       | Has `ISelector` |

When modifiers are separate, i.e. `+F +S`, it means there's an overload with `IFilter`, overload with `ISelector`, but not both.

When modifiers are combined, i.e. `+FS`, it means all possible permutations are available, in other words, there's also
an overload which has `IFilter` AND `ISelector` together.

## Added Helpers for Properties

Every property exposed by an interface now has a helper for retrieving it.

Before (`KeyValuePair`):

```csharp
root.Value.Item.IsFile
```

Before (`KeyedBox` / `Box`):

```csharp
root.Item.IsFile
```

After:

```csharp
root.IsFile()
```

The KeyValuePair situation was incredibly inconvenient due to heavy use of enumerators in NMA, so typing `node.Value.Item.PROPERTY` in Linq predicates was excessive. Now with extensions for reading each property, that should become less an issue.