### PR TITLE
Fix TemporaryFileManager not deleting directories correctly

### DIFF
--- a/src/NexusMods.Paths/FileSystemAbstraction/InMemoryFileSystem/InMemoryFileSystem.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/InMemoryFileSystem/InMemoryFileSystem.cs
@@ -357,6 +357,8 @@ public partial class InMemoryFileSystem : BaseFileSystem
             InternalDeleteDirectoryRecursive(subDirectory.Path);
         }
 
+        // Don't remove this from parent.Directories since parent is iterating over it
+        
         _directories.Remove(path);
     }
 

--- a/src/NexusMods.Paths/FileSystemAbstraction/InMemoryFileSystem/InMemoryFileSystem.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/InMemoryFileSystem/InMemoryFileSystem.cs
@@ -306,6 +306,7 @@ public partial class InMemoryFileSystem : BaseFileSystem
         _files.Remove(path);
     }
 
+
     /// <inheritdoc/>
     protected override void InternalDeleteDirectory(AbsolutePath path, bool recursive)
     {
@@ -323,7 +324,7 @@ public partial class InMemoryFileSystem : BaseFileSystem
             foreach (var kv in directory.Directories)
             {
                 var (_, subDirectory) = kv;
-                InternalDeleteDirectory(subDirectory.Path, true);
+                InternalDeleteDirectoryRecursive(subDirectory.Path);
             }
         }
         else
@@ -333,8 +334,32 @@ public partial class InMemoryFileSystem : BaseFileSystem
 
         }
 
+        var parentDirectory = directory.ParentDirectory;
+        parentDirectory.Directories.Remove(path.RelativeTo(parentDirectory.Path));
         _directories.Remove(path);
     }
+
+    private void InternalDeleteDirectoryRecursive(AbsolutePath path)
+    {
+        // Don't throw if the directory doesn't exist
+        if (!_directories.TryGetValue(path, out var directory))
+            return;
+
+        foreach (var kv in directory.Files)
+        {
+            var (_, file) = kv;
+            _files.Remove(file.Path);
+        }
+
+        foreach (var kv in directory.Directories)
+        {
+            var (_, subDirectory) = kv;
+            InternalDeleteDirectoryRecursive(subDirectory.Path);
+        }
+
+        _directories.Remove(path);
+    }
+
 
     /// <inheritdoc/>
     protected override void InternalMoveFile(AbsolutePath source, AbsolutePath dest, bool overwrite)

--- a/src/NexusMods.Paths/TemporaryFileManager.cs
+++ b/src/NexusMods.Paths/TemporaryFileManager.cs
@@ -136,8 +136,19 @@ public readonly struct TemporaryPath : IDisposable, IAsyncDisposable
 
     private void Dispose_Impl()
     {
-        if (_deleteOnDispose && _fileSystem.FileExists(Path))
+        if (!_deleteOnDispose)
+            return;
+
+        if (_fileSystem.FileExists(Path))
+        {
             _fileSystem.DeleteFile(Path);
+            return;
+        }
+
+        if (_fileSystem.DirectoryExists(Path))
+        {
+            _fileSystem.DeleteDirectory(Path, recursive: true);
+        }
     }
 
     /// <inheritdoc />

--- a/tests/NexusMods.Paths.Tests/TemporaryPathTests.cs
+++ b/tests/NexusMods.Paths.Tests/TemporaryPathTests.cs
@@ -59,9 +59,5 @@ public class TemporaryPathTests
         fs.FileExists(childFileB).Should().BeFalse();
         fs.DirectoryExists(childFolder).Should().BeFalse();
         fs.DirectoryExists(tempDirPath).Should().BeFalse();
-
-        // InMemoryFileSystem throws if created stuff is no longer there when cleaning up
-
-
     }
 }

--- a/tests/NexusMods.Paths.Tests/TemporaryPathTests.cs
+++ b/tests/NexusMods.Paths.Tests/TemporaryPathTests.cs
@@ -30,4 +30,38 @@ public class TemporaryPathTests
         fs.FileExists(deletedPath).Should().BeFalse();
         fs.FileExists(notDeletedPath).Should().BeTrue();
     }
+
+    [Theory, AutoFileSystem]
+    public async Task DirectoriesAreDeleted(InMemoryFileSystem fs, TemporaryFileManager manager)
+    {
+        var tempDirPath = manager.CreateFolder();
+
+        // Create some children
+        var childFileA = tempDirPath.Path.Combine("File A");
+        fs.CreateFile(childFileA);
+
+        var childFolder = tempDirPath.Path.Combine("Child Folder");
+        fs.CreateDirectory(childFolder);
+        var childFileB = childFolder.Combine("File B");
+        fs.CreateFile(childFileB);
+
+
+        await fs.WriteAllTextAsync(childFileA, "File A");
+        await fs.WriteAllTextAsync(childFileB, "File B");
+
+        fs.DirectoryExists(tempDirPath).Should().BeTrue();
+        fs.FileExists(childFileA).Should().BeTrue();
+        fs.FileExists(childFileB).Should().BeTrue();
+
+        await tempDirPath.DisposeAsync();
+
+        fs.FileExists(childFileA).Should().BeFalse();
+        fs.FileExists(childFileB).Should().BeFalse();
+        fs.DirectoryExists(childFolder).Should().BeFalse();
+        fs.DirectoryExists(tempDirPath).Should().BeFalse();
+
+        // InMemoryFileSystem throws if created stuff is no longer there when cleaning up
+
+
+    }
 }


### PR DESCRIPTION
fixes https://github.com/Nexus-Mods/NexusMods.App/issues/904

When adding the test I found that the InMemoryFS was throwing when deleting the folder recursively, so fixed that as well.