### PR TITLE
Update `KnownExtensions` to make fields readonly

### DIFF
--- a/src/NexusMods.Paths/Utilities/KnownExtensions.cs
+++ b/src/NexusMods.Paths/Utilities/KnownExtensions.cs
@@ -6,47 +6,47 @@ namespace NexusMods.Paths.Utilities;
 public static class KnownExtensions
 {
     /// <summary>.archive</summary>
-    public static Extension Archive = new(".archive");
+    public static readonly Extension Archive = new(".archive");
 
     /// <summary>.preset</summary>
-    public static Extension Preset = new(".preset");
+    public static readonly Extension Preset = new(".preset");
 
     /// <summary>.zip</summary>
-    public static Extension Zip = new(".zip");
+    public static readonly Extension Zip = new(".zip");
 
     /// <summary>.7z</summary>
-    public static Extension _7z = new(".7z");
+    public static readonly Extension _7z = new(".7z");
 
     /// <summary>.7zip ; uncommon/rare.</summary>
-    public static Extension _7zip = new(".7zip");
+    public static readonly Extension _7zip = new(".7zip");
 
     /// <summary>.rar</summary>
-    public static Extension Rar = new(".rar");
+    public static readonly Extension Rar = new(".rar");
 
     /// <summary>.json</summary>
-    public static Extension Json = new(".json");
+    public static readonly Extension Json = new(".json");
 
     /// <summary>.txt</summary>
-    public static Extension Txt = new(".txt");
+    public static readonly Extension Txt = new(".txt");
 
     /// <summary>.tmp</summary>
-    public static Extension Tmp = new(".tmp");
+    public static readonly Extension Tmp = new(".tmp");
 
     /// <summary>.sqlite</summary>
-    public static Extension Sqlite = new(".sqlite");
+    public static readonly Extension Sqlite = new(".sqlite");
 
     /// <summary>.md</summary>
-    public static Extension Md = new(".md");
-    
+    public static readonly Extension Md = new(".md");
+
     /// <summary>.nx</summary>
-    public static Extension Nx = new(".nx");
-    
+    public static readonly Extension Nx = new(".nx");
+
     /// <summary>.pdf</summary>
-    public static Extension Pdf = new(".pdf");
+    public static readonly Extension Pdf = new(".pdf");
 
     /// <summary>.png</summary>
-    public static Extension Png = new(".png");
+    public static readonly Extension Png = new(".png");
 
     /// <summary>.ra</summary>
-    public static Extension Ra = new(".ra");
+    public static readonly Extension Ra = new(".ra");
 }


### PR DESCRIPTION
Our library currently suffers from [CA2211](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2211) when building locally. Presumably, at some point, our common NuGet Props were updated, and the introduction of new rules added alongside them, broke the build.

This PR simply makes the fields `readonly`, to avoid the issue; as the fields shouldn't be mutated in the first place (they're meant to be constants).