### PR TITLE
Improve performance of `JoinParts` for spans

### DIFF
--- a/src/NexusMods.Paths.Benchmarks/Benchmarks/Pr42.cs
+++ b/src/NexusMods.Paths.Benchmarks/Benchmarks/Pr42.cs
@@ -30,13 +30,13 @@ public class Pr42 : IBenchmark
     [Benchmark]
     public string Current()
     {
-        return PathHelpers.JoinParts(Path1, Path2, _osInformation);
+        return PathHelpers.JoinParts(Path1.AsSpan(), Path2.AsSpan(), _osInformation);
     }
 
     [Benchmark]
     public string OldMethod()
     {
-        return JoinParts(Path1, Path2, _osInformation);
+        return JoinParts(Path1.AsSpan(), Path2.AsSpan(), _osInformation);
     }
 
     [SkipLocalsInit] // original method didn't have it, but it's still good for comparison.

--- a/src/NexusMods.Paths.Benchmarks/Benchmarks/Pr42.cs
+++ b/src/NexusMods.Paths.Benchmarks/Benchmarks/Pr42.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using NexusMods.Paths.Benchmarks.Interfaces;
+using NexusMods.Paths.Utilities;
+
+namespace NexusMods.Paths.Benchmarks.Benchmarks;
+
+[BenchmarkInfo("PR42", "Comparison for PR #42")]
+[MemoryDiagnoser]
+public class Pr42 : IBenchmark
+{
+    [Params(@"short", @"a/very/long/path/indeed/to/see/how/it/performs")]
+    public string Path1 { get; set; } = null!;
+
+    [Params("short", "a/very/long/path/indeed/to/see/how/it/performs")]
+    public string Path2 { get; set; } = null!;
+
+    private readonly IOSInformation _osInformation;
+
+    public Pr42()
+    {
+        _osInformation = OSInformation.Shared;
+    }
+
+    [Benchmark]
+    public string Current()
+    {
+        return PathHelpers.JoinParts(Path1, Path2, _osInformation);
+    }
+
+    [Benchmark]
+    public string OldMethod()
+    {
+        return JoinParts(Path1, Path2, _osInformation);
+    }
+
+    [SkipLocalsInit] // original method didn't have it, but it's still good for comparison.
+    private static string JoinParts(ReadOnlySpan<char> left, ReadOnlySpan<char> right, IOSInformation os)
+    {
+        var spanLength = PathHelpers.GetExactJoinedPartLength(left, right);
+        var buffer = spanLength > 512
+            ? GC.AllocateUninitializedArray<char>(spanLength)
+            : stackalloc char[spanLength];
+
+        var count = PathHelpers.JoinParts(buffer, left, right, os);
+        if (count == 0) return string.Empty;
+        return buffer.ToString();
+    }
+}

--- a/src/NexusMods.Paths.Benchmarks/NexusMods.Paths.Benchmarks.csproj
+++ b/src/NexusMods.Paths.Benchmarks/NexusMods.Paths.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/NexusMods.Paths/Utilities/PathHelpers.cs
+++ b/src/NexusMods.Paths/Utilities/PathHelpers.cs
@@ -388,6 +388,12 @@ public static class PathHelpers
         var spanLength = GetExactJoinedPartLength(left, right);
         unsafe
         {
+            // Note: We're deconstructing and reconstructing a span here, because we cannot
+            // pass ref-structs (Span) via a delegate (SpanAction). This is a workaround for
+            // said issue.
+
+            // This isn't the only way to pin, it's also possible to pin via refs.
+            // Just that this is the more readable approach to the problem.
             fixed (char* leftPtr = left)
             fixed (char* rightPtr = right)
             {


### PR DESCRIPTION
This improves the performance of the `JoinParts` method, by avoiding an unnecessary heap allocation which makes another copy of the string.

We pin the Span (in the case it originated from the heap), and use the pointers to the characters as input to `string.Create`.