### PR TITLE
Add missing `SkipLocalsInit`

### DIFF
--- a/src/NexusMods.Paths/AbsolutePath.cs
+++ b/src/NexusMods.Paths/AbsolutePath.cs
@@ -251,6 +251,7 @@ public readonly partial struct AbsolutePath : IEquatable<AbsolutePath>, IPath<Ab
     /// </remarks>
     /// <param name="other">The path from which the relative path should be made.</param>
     /// <throws><see cref="PathException"/> if the paths are not in the same folder.</throws>
+    [SkipLocalsInit]
     public RelativePath RelativeTo(AbsolutePath other)
     {
         var childLength = GetFullPathLength();
@@ -272,6 +273,7 @@ public readonly partial struct AbsolutePath : IEquatable<AbsolutePath>, IPath<Ab
     }
 
     /// <inheritdoc />
+    [SkipLocalsInit]
     public bool InFolder(AbsolutePath parent)
     {
         var parentLength = parent.GetFullPathLength();

--- a/src/NexusMods.Paths/RelativePath.cs
+++ b/src/NexusMods.Paths/RelativePath.cs
@@ -305,7 +305,6 @@ public readonly struct RelativePath : IPath<RelativePath>, IEquatable<RelativePa
     }
 
     /// <inheritdoc />
-    [SkipLocalsInit]
     public override int GetHashCode()
     {
         // A custom HashCode, based on FNV-1 with added Vectorization because the default one is very slow for our use in trees, dictionaries, etc.

--- a/src/NexusMods.Paths/Utilities/PathHelpers.cs
+++ b/src/NexusMods.Paths/Utilities/PathHelpers.cs
@@ -117,6 +117,7 @@ public static class PathHelpers
     /// Sanitizes the given path. Only sanitized paths should be used with
     /// <see cref="PathHelpers"/>.
     /// </summary>
+    [SkipLocalsInit]
     public static string Sanitize(ReadOnlySpan<char> path, IOSInformation os)
     {
         // Path has already been sanitized.
@@ -155,6 +156,7 @@ public static class PathHelpers
     /// Assumes sanitized path, changes to `/` on Unix-based systems and `\` on Windows.
     /// </remarks>
     /// </summary>
+    [SkipLocalsInit]
     public static string ToNativeSeparators(ReadOnlySpan<char> path, IOSInformation os)
     {
         DebugAssertIsSanitized(path, os);


### PR DESCRIPTION
Somewhere in transition between the initial code I wrote for this library, and now, we've reworked some method, or moved their implementations elsewhere. 

Along the way, during that process we forgot to add `SkipLocalsInit` in the methods which use `stackalloc` in some places. This results in stack allocated memory to be zeroed. As we know, the exact lengths of strings we need in these scenarios, we can opt into not zeroing them.