### PR TITLE
Updated: Direct Dependency Versions for Paths

### DIFF
--- a/src/NexusMods.Paths/NexusMods.Paths.csproj
+++ b/src/NexusMods.Paths/NexusMods.Paths.csproj
@@ -6,9 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-        <PackageReference Include="Reloaded.Memory" Version="9.3.0" />
-        <PackageReference Include="Vogen" Version="3.0.20" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+        <PackageReference Include="Reloaded.Memory" Version="9.4.1" />
+        <PackageReference Include="Vogen" Version="3.0.24" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This updates our dependencies. Nothing more, nothing less.

Main motivator for this lies in updating string hashing logic.

Due to the strange bug observed the other day, where in App, the string hash function won't be promoted to Tier 1 until approx 700k (500000 startup, 200000 after) calls on my machine; the functions were marked with `MethodImplOptions.AggressiveOptimization` (i.e. produce non-instrumented Tier 1 code immediately) to avoid this issue. 

This is OK, as the function does not benefit from PGO given how its used in context. No other major changes. I guess hash distribution is a bit better for smaller non-vectorised strings, but that's about it.