### PR TITLE
Added: Method to Obtain Real Path of a FileSystem File

### DIFF
--- a/src/NexusMods.Paths/Utilities/FileSystemMarshal.cs
+++ b/src/NexusMods.Paths/Utilities/FileSystemMarshal.cs
@@ -1,10 +1,9 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace NexusMods.Paths.Utilities;
 
 /// <summary>
-///     This is a suite of low level methods that provide 'escape hatches' for the
-///     file system abstraction where lower level access is required.
+///     This is a suite of low level methods that provide 'escape hatches' and
+///     other utilities for the file system abstraction where lower level access
+///     is required.
 /// </summary>
 /// <remarks>
 ///     This is named after classes like
@@ -31,7 +30,7 @@ public static class FileSystemMarshal
     ///     that works with the <see cref="IFileSystem"/> abstraction, or throw
     ///     an exception.
     /// </remarks>
-    public static bool TryResolveRealFilesystemPath(AbsolutePath path, [MaybeNullWhen(false)] out string? fullFilePath)
+    public static bool TryResolveRealFilesystemPath(AbsolutePath path, out string? fullFilePath)
     {
         // Only paths from the Real 'FileSystem' can be resolved here.
         if (path.FileSystem is not FileSystem realFs)

--- a/src/NexusMods.Paths/Utilities/FileSystemMarshal.cs
+++ b/src/NexusMods.Paths/Utilities/FileSystemMarshal.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace NexusMods.Paths.Utilities;
+
+/// <summary>
+///     This is a suite of low level methods that provide 'escape hatches' for the
+///     file system abstraction where lower level access is required.
+/// </summary>
+/// <remarks>
+///     This is named after classes like
+///     <a href="https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.collectionsmarshal?view=net-8.0">CollectionsMarshal</a>
+///     in the .NET Runtime.
+/// </remarks>
+public static class FileSystemMarshal
+{
+    /// <summary>
+    ///     Tries to resolve the path of the file to a path in the real
+    ///     FileSystem.
+    ///
+    ///     This acts as an 'escape hatch' for using real FileSystem functionality
+    ///     which is not yet available as part of the <see cref="IFileSystem"/> abstraction.
+    /// </summary>
+    /// <param name="path">The path of the file.</param>
+    /// <param name="fullFilePath">File path to the raw file on the FileSystem.</param>
+    /// <returns>
+    ///     True if the path was successfully resolved to a real file on disk,
+    ///     otherwise false.
+    /// </returns>
+    /// <remarks>
+    ///     If this method returns 'false' you should fall back to a slower implementation
+    ///     that works with the <see cref="IFileSystem"/> abstraction, or throw
+    ///     an exception.
+    /// </remarks>
+    public static bool TryResolveRealFilesystemPath(AbsolutePath path, [MaybeNullWhen(false)] out string? fullFilePath)
+    {
+        // Only paths from the Real 'FileSystem' can be resolved here.
+        if (path.FileSystem is not FileSystem realFs)
+        {
+            fullFilePath = null;
+            return false;
+        }
+
+        // Resolve the path.
+        fullFilePath = realFs.GetMappedPath(path).GetFullPath();
+        return true;
+    }
+}

--- a/tests/NexusMods.Paths.Tests/NexusMods.Paths.Tests.csproj
+++ b/tests/NexusMods.Paths.Tests/NexusMods.Paths.Tests.csproj
@@ -14,8 +14,4 @@
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
     </ItemGroup>
-
-    <ItemGroup>
-      <Folder Include="Utilities\" />
-    </ItemGroup>
 </Project>

--- a/tests/NexusMods.Paths.Tests/NexusMods.Paths.Tests.csproj
+++ b/tests/NexusMods.Paths.Tests/NexusMods.Paths.Tests.csproj
@@ -14,4 +14,8 @@
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
     </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="Utilities\" />
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
# Summary

This PR adds `FileSystemMarshal` utility class, which provides an 'escape hatch' and lower level utilities for the file system abstraction (`IFileSystem`) when necessary.

This name is based on the names of similar classes in the .NET Runtime, for example [CollectionsMarshal](<https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.collectionsmarshal?view=net-8.0>), [MemoryMarshal](<https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.memorymarshal?view=net-8.0>)

## Purpose

Currently this provides the method, `TryResolveRealFilesystemPath`, which provides the real, on disk path of a file in the `RealFileSystem` (now called `FileSystem`). In other words, this respects the file redirections we have put in place.

Example usage:
```csharp
if (FileSystemMarshal.TryResolveRealFilesystemPath(path, out var realFilePath))
{
    // Use the realFilePath to create a Memory Mapped File
    // or some other functionality that's not currently supported
    // ...
}
else
{
    // Fall back to a slower/legacy implementation or throw an exception
    // ...
}
```

This should be used sparingly, only when not using the abstraction provides tangle benefit.

## Tests

Included tests in this PR. For sanity purposes.

## Current Purpose

I want to use `Memory Mapped Files` (with precise control). We currently don't have an abstraction available in `IFileSystem`. This can serve as a temporary workaround till then.

Hopefully afterwards, we can gradually make APIs for mmap, and any other missing APIs.