### PR TITLE
Added: Existing-File-Only IFileSystem MemoryMappedFile Abstraction

### DIFF
--- a/src/NexusMods.Paths/AbsolutePath.cs
+++ b/src/NexusMods.Paths/AbsolutePath.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 using NexusMods.Paths.Utilities;

--- a/src/NexusMods.Paths/FileSystemAbstraction/BaseFileSystem.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/BaseFileSystem.cs
@@ -424,7 +424,7 @@ public abstract class BaseFileSystem : IFileSystem
     /// <inheritdoc/>
     public MemoryMappedFileHandle CreateMemoryMappedFile(AbsolutePath absPath, FileMode mode, MemoryMappedFileAccess access)
     {
-        return InternalCreateMemoryMappedFile(absPath, mode, access);
+        return InternalCreateMemoryMappedFile(GetMappedPath(absPath), mode, access);
     }
 
     #endregion

--- a/src/NexusMods.Paths/FileSystemAbstraction/BaseFileSystem.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/BaseFileSystem.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.IO.MemoryMappedFiles;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -420,6 +421,12 @@ public abstract class BaseFileSystem : IFileSystem
         return default;
     }
 
+    /// <inheritdoc/>
+    public MemoryMappedFileHandle CreateMemoryMappedFile(AbsolutePath absPath, FileMode mode, MemoryMappedFileAccess access)
+    {
+        return InternalCreateMemoryMappedFile(absPath, mode, access);
+    }
+
     #endregion
 
     #region Abstract Methods
@@ -460,5 +467,7 @@ public abstract class BaseFileSystem : IFileSystem
     /// <inheritdoc cref="IFileSystem.MoveFile"/>
     protected abstract void InternalMoveFile(AbsolutePath source, AbsolutePath dest, bool overwrite);
 
+    /// <inheritdoc cref="IFileSystem.CreateMemoryMappedFile"/>
+    protected abstract MemoryMappedFileHandle InternalCreateMemoryMappedFile(AbsolutePath absPath, FileMode mode, MemoryMappedFileAccess access);
     #endregion
 }

--- a/src/NexusMods.Paths/FileSystemAbstraction/IFileSystem.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/IFileSystem.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.IO.MemoryMappedFiles;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -279,4 +280,12 @@ public interface IFileSystem
     ///     On non-Unix based systems, or FileSystems without perms, this is a no-operation.
     /// </remarks>
     UnixFileMode GetUnixFileMode(AbsolutePath absolutePath);
+
+    /// <summary>
+    ///     Creates a new 'Memory Mapped File' from the existing file.
+    /// </summary>
+    /// <param name="absPath">Path of the file to memory map.</param>
+    /// <param name="mode">The mode the file is opened with.</param>
+    /// <param name="access">What you intend to do with the memory mapped file.</param>
+    MemoryMappedFileHandle CreateMemoryMappedFile(AbsolutePath absPath, FileMode mode, MemoryMappedFileAccess access);
 }

--- a/src/NexusMods.Paths/FileSystemAbstraction/InMemoryFileSystem/InMemoryFileEntry.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/InMemoryFileSystem/InMemoryFileEntry.cs
@@ -42,22 +42,23 @@ public partial class InMemoryFileSystem
             throw new NotImplementedException();
         }
 
-        public Stream CreateReadStream()
+        public MemoryStream CreateReadStream()
         {
             var ms = new MemoryStream(_contents, 0, _contents.Length, false);
             return ms;
         }
 
-        public Stream CreateWriteStream()
+        public MemoryStream CreateWriteStream()
         {
             var stream = new MemoryStreamWrapper(this);
             return stream;
         }
 
-        public Stream CreateReadWriteStream()
+        public MemoryStream CreateReadWriteStream()
         {
             var stream = new MemoryStreamWrapper(this);
             stream.Write(_contents);
+            stream.Position = 0;
             return stream;
         }
 

--- a/src/NexusMods.Paths/FileSystemAbstraction/MemoryMappedFileHandle.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/MemoryMappedFileHandle.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace NexusMods.Paths;
+
+/// <summary>
+///     This represents a 'handle' to an underlying MemoryMappedFile.
+/// </summary>
+public readonly unsafe struct MemoryMappedFileHandle : IDisposable
+{
+    /// <summary>
+    ///     Address of the data represented by this handle.
+    /// </summary>
+    public byte* Pointer { get; }
+
+    /// <summary>
+    ///     Length of the data represented by this handle.
+    /// </summary>
+    public nuint Length { get; }
+    private readonly IDisposable? _owner;
+
+    /// <inheritdoc />
+    public MemoryMappedFileHandle() : this((byte*)0, 0, null) { }
+
+    /// <summary>
+    ///    Creates a handle for a new MemoryMappedFile.
+    /// </summary>
+    /// <param name="pointer">Pointer to the mapped data.</param>
+    /// <param name="length">Length of the data represented by the handle.</param>
+    /// <param name="owner">Whatever holds the raw handle under the hood.</param>
+    public MemoryMappedFileHandle(byte* pointer, nuint length, IDisposable? owner)
+    {
+        Pointer = pointer;
+        Length = length;
+        _owner = owner;
+    }
+
+    /// <summary>
+    ///     Returns the data in span form.
+    /// </summary>
+    public Span<byte> AsSpan() => new(Pointer, (int)Length);
+
+    /// <inheritdoc />
+    public void Dispose() => _owner?.Dispose();
+}

--- a/src/NexusMods.Paths/FileSystemAbstraction/MemoryMappedFileHandle.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/MemoryMappedFileHandle.cs
@@ -1,10 +1,12 @@
 using System;
+using JetBrains.Annotations;
 
 namespace NexusMods.Paths;
 
 /// <summary>
 ///     This represents a 'handle' to an underlying MemoryMappedFile.
 /// </summary>
+[PublicAPI]
 public readonly unsafe struct MemoryMappedFileHandle : IDisposable
 {
     /// <summary>

--- a/src/NexusMods.Paths/FileSystemAbstraction/RealFileSystem/FileSystem.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/RealFileSystem/FileSystem.cs
@@ -246,6 +246,7 @@ public partial class FileSystem : BaseFileSystem
     #endregion
 
     // Note(Sewer): This is taken straight from Runtime.
+    // https://github.com/dotnet/runtime/blob/3a78480ae21a909ecd3ac9edfd2aa3e63dd890fb/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.cs#L486
     private static FileAccess GetFileAccess(MemoryMappedFileAccess access)
     {
         switch (access)

--- a/src/NexusMods.Paths/FileSystemAbstraction/RealFileSystem/FileSystem.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/RealFileSystem/FileSystem.cs
@@ -230,8 +230,7 @@ public partial class FileSystem : BaseFileSystem
     /// <inheritdoc/>
     protected override unsafe MemoryMappedFileHandle InternalCreateMemoryMappedFile(AbsolutePath absPath, FileMode mode, MemoryMappedFileAccess access)
     {
-        var targetPath = GetMappedPath(absPath).GetFullPath();
-        var fs = new FileStream(targetPath, new FileStreamOptions
+        var fs = new FileStream(absPath.GetFullPath(), new FileStreamOptions
         {
             Mode = mode,
             Access = GetFileAccess(access),

--- a/src/NexusMods.Paths/FileSystemAbstraction/RealFileSystem/FilesystemMemoryMappedHandle.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/RealFileSystem/FilesystemMemoryMappedHandle.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO.MemoryMappedFiles;
+
+namespace NexusMods.Paths;
+
+/// <summary>
+///     Represents a 'handle' to a memory mapped file on the Real FileSystem.
+/// </summary>
+internal class FilesystemMemoryMappedHandle : IDisposable
+{
+    private readonly MemoryMappedViewAccessor _accessor;
+    private readonly MemoryMappedFile _memoryMappedFile;
+
+    /// <summary/>
+    public FilesystemMemoryMappedHandle(MemoryMappedViewAccessor accessor, MemoryMappedFile memoryMappedFile)
+    {
+        _accessor = accessor;
+        _memoryMappedFile = memoryMappedFile;
+    }
+
+    public void Dispose()
+    {
+        _accessor.Dispose();
+        _memoryMappedFile.Dispose();
+    }
+}

--- a/tests/NexusMods.Paths.Tests/FileSystem/FileSystemTests.cs
+++ b/tests/NexusMods.Paths.Tests/FileSystem/FileSystemTests.cs
@@ -1,3 +1,4 @@
+using System.IO.MemoryMappedFiles;
 using System.Reflection;
 using FluentAssertions;
 
@@ -41,5 +42,24 @@ public class FileSystemTests
         fs.EnumerateFileEntries(directory, recursive: false)
             .Should()
             .Contain(x => x.Path == file);
+    }
+
+    [Fact]
+    public async Task Test_CreateMemoryMappedFile_CanOpen()
+    {
+        var fs = new Paths.FileSystem();
+        var file = fs.FromUnsanitizedFullPath(Assembly.GetExecutingAssembly().Location);
+        var expectedData = await file.ReadAllBytesAsync();
+
+        unsafe
+        {
+            using var mmf = fs.CreateMemoryMappedFile(file, FileMode.Open, MemoryMappedFileAccess.ReadWrite);
+            mmf.Should().NotBeNull();
+            ((nuint)mmf.Pointer).Should().NotBe(0);
+            mmf.Length.Should().Be((nuint)file.FileInfo.Size);
+
+            // Assert that the contents are equal
+            mmf.AsSpan().SequenceEqual(expectedData).Should().BeTrue();
+        }
     }
 }

--- a/tests/NexusMods.Paths.Tests/FileSystem/FileSystemTests.cs
+++ b/tests/NexusMods.Paths.Tests/FileSystem/FileSystemTests.cs
@@ -1,5 +1,6 @@
 using System.IO.MemoryMappedFiles;
 using System.Reflection;
+using NexusMods.Paths.TestingHelpers;
 
 namespace NexusMods.Paths.Tests.FileSystem;
 

--- a/tests/NexusMods.Paths.Tests/FileSystem/InMemoryFileSystemTests.cs
+++ b/tests/NexusMods.Paths.Tests/FileSystem/InMemoryFileSystemTests.cs
@@ -1,3 +1,4 @@
+using System.IO.MemoryMappedFiles;
 using NexusMods.Paths.TestingHelpers;
 
 namespace NexusMods.Paths.Tests.FileSystem;

--- a/tests/NexusMods.Paths.Tests/FileSystem/InMemoryFileSystemTests.cs
+++ b/tests/NexusMods.Paths.Tests/FileSystem/InMemoryFileSystemTests.cs
@@ -1,3 +1,4 @@
+using System.IO.MemoryMappedFiles;
 using FluentAssertions;
 using NexusMods.Paths.TestingHelpers;
 
@@ -342,5 +343,23 @@ public class InMemoryFileSystemTests
         fs.FileExists(dest).Should().BeTrue();
 
         fs.GetFileEntry(dest).Size.Should().Be(Size.FromLong(contents.Length));
+    }
+
+    [Theory, AutoFileSystem]
+    public void Test_CreateMemoryMappedFile_CanOpen(InMemoryFileSystem fs,
+        AbsolutePath file, byte[] contents)
+    {
+        fs.AddFile(file, contents);
+
+        unsafe
+        {
+            using var mmf = fs.CreateMemoryMappedFile(file, FileMode.Open, MemoryMappedFileAccess.ReadWrite);
+            mmf.Should().NotBeNull();
+            ((nuint)mmf.Pointer).Should().NotBe(0);
+            mmf.Length.Should().Be((nuint)file.FileInfo.Size);
+
+            // Assert that the contents are equal
+            mmf.AsSpan().SequenceEqual(contents).Should().BeTrue();
+        }
     }
 }


### PR DESCRIPTION
Adds an abstraction for MemoryMappedFiles suitable for reading existing files.
Nothing less, nothing more. The bare minimum, most lazy implementation as requested.

If you ever want to add more, just try matching the overloads of `MemoryMappedFile.CreateFromFile` and `memoryMappedFile.CreateViewAccessor` combined.