### PR TITLE
Fix `DeleteDirectory` throwing when trying to delete empty folders

### DIFF
--- a/src/NexusMods.Paths/FileSystemAbstraction/RealFileSystem/FileSystem.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/RealFileSystem/FileSystem.cs
@@ -147,9 +147,9 @@ public partial class FileSystem : BaseFileSystem
 
         if (!recursive)
         {
-            var isEmpty = EnumerateFiles(path, recursive: false).Any() ||
+            var hasChildren = EnumerateFiles(path, recursive: false).Any() ||
                           EnumerateDirectories(path, recursive: false).Any();
-            if (!isEmpty)
+            if (hasChildren)
             {
                 throw new IOException($"The directory {fullPath} is not empty and {nameof(recursive)} is set to {recursive}");
             }

--- a/tests/NexusMods.Paths.Tests/FileSystem/FileSystemTests.cs
+++ b/tests/NexusMods.Paths.Tests/FileSystem/FileSystemTests.cs
@@ -32,6 +32,43 @@ public class FileSystemTests
     }
 
     [Fact]
+    public void Test_DeleteDirectoryShouldDeleteEmpty()
+    {
+        var fs = new Paths.FileSystem();
+
+        var directory = fs.FromUnsanitizedFullPath(AppContext.BaseDirectory).Combine("TestDirectory");
+        fs.CreateDirectory(directory);
+
+        fs.DeleteDirectory(directory, recursive: false);
+
+        fs.DirectoryExists(directory).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Test_DeleteDirectoryShouldNotDeleteNonEmpty()
+    {
+        var fs = new Paths.FileSystem();
+
+        var directory = fs.FromUnsanitizedFullPath(AppContext.BaseDirectory).Combine("TestDirectory");
+        var child = directory.Combine("Child");
+
+        fs.CreateDirectory(directory);
+        fs.CreateDirectory(child);
+
+        var action = () => fs.DeleteDirectory(directory, recursive: false);
+        action.Should().Throw<IOException>();
+
+        // Cleanup to avoid breaking the other tests
+        fs.DeleteDirectory(child, recursive: false);
+
+        fs.DirectoryExists(child).Should().BeFalse();
+
+        fs.DeleteDirectory(directory, recursive: false);
+
+        fs.DirectoryExists(directory).Should().BeFalse();
+    }
+
+    [Fact]
     public void Test_EnumerateFileEntries()
     {
         var fs = new Paths.FileSystem();


### PR DESCRIPTION
- fixes https://github.com/Nexus-Mods/NexusMods.App/issues/1213

Added a couple of tests to cover this