### PR TITLE
Added: Improved Error Handling for Creating Memory Mapped Files

### DIFF
--- a/src/NexusMods.Paths/FileSystemAbstraction/RealFileSystem/FileSystem.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/RealFileSystem/FileSystem.cs
@@ -242,7 +242,7 @@ public partial class FileSystem : BaseFileSystem
         try
         {
             mmf = MemoryMappedFile.CreateFromFile(fs, null, fs.Length, access, HandleInheritability.None, false);
-            view = mmf.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
+            view = mmf.CreateViewAccessor(0, 0, access);
             var ptrData = (byte*)view.SafeMemoryMappedViewHandle.DangerousGetHandle();
             return new MemoryMappedFileHandle(ptrData, (nuint)fs.Length, new FilesystemMemoryMappedHandle(view, mmf));
         }


### PR DESCRIPTION
This tiny PR improves the error handling mechanism of creating Memory Mapped Files.

Previously an error (exception) in mapped file creation could technically result in a file handle that's not immediately dropped (till GC). Which later, down the road, could present itself as 'file is in use' on Windows.