### PR TITLE
Set the Created/Modified dates when creating in-memory file system entries

### DIFF
--- a/src/NexusMods.Paths/FileSystemAbstraction/InMemoryFileSystem/InMemoryFileSystem.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/InMemoryFileSystem/InMemoryFileSystem.cs
@@ -84,8 +84,8 @@ public partial class InMemoryFileSystem : BaseFileSystem
         _files.Add(path, inMemoryFile);
         directory.Files.Add(inMemoryFile.Path.RelativeTo(directory.Path), inMemoryFile);
 
-        inMemoryFile.CreationTime = DateTime.Now;
-        inMemoryFile.LastWriteTime = DateTime.Now;
+        inMemoryFile.CreationTime = DateTime.UtcNow;
+        inMemoryFile.LastWriteTime = DateTime.UtcNow;
         return inMemoryFile;
     }
 
@@ -290,7 +290,7 @@ public partial class InMemoryFileSystem : BaseFileSystem
         if (inMemoryFileEntry is null)
             throw new FileNotFoundException($"File \"{path.GetFullPath()}\" does not exist");
 
-        inMemoryFileEntry.LastWriteTime = DateTime.Now;
+        inMemoryFileEntry.LastWriteTime = DateTime.UtcNow;
         return inMemoryFileEntry;
     }
 

--- a/src/NexusMods.Paths/FileSystemAbstraction/InMemoryFileSystem/InMemoryFileSystem.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/InMemoryFileSystem/InMemoryFileSystem.cs
@@ -84,6 +84,8 @@ public partial class InMemoryFileSystem : BaseFileSystem
         _files.Add(path, inMemoryFile);
         directory.Files.Add(inMemoryFile.Path.RelativeTo(directory.Path), inMemoryFile);
 
+        inMemoryFile.CreationTime = DateTime.Now;
+        inMemoryFile.LastWriteTime = DateTime.Now;
         return inMemoryFile;
     }
 
@@ -288,6 +290,7 @@ public partial class InMemoryFileSystem : BaseFileSystem
         if (inMemoryFileEntry is null)
             throw new FileNotFoundException($"File \"{path.GetFullPath()}\" does not exist");
 
+        inMemoryFileEntry.LastWriteTime = DateTime.Now;
         return inMemoryFileEntry;
     }
 


### PR DESCRIPTION
These were defaulting to time 0, or Jan 1st, 0001. Which was causing issues in my attempts to make the datamodel tests completely in-memory