### PR TITLE
Make RelativePath constructor internal

### DIFF
--- a/src/NexusMods.Paths.TestingHelpers/Customizations.cs
+++ b/src/NexusMods.Paths.TestingHelpers/Customizations.cs
@@ -40,10 +40,7 @@ public static class Customizations
                 return fs.FromUnsanitizedFullPath(fullPath);
             }));
 
-        fixture.Customize<RelativePath>(composer =>
-            composer.FromFactory<string>(path => new RelativePath(path)));
-
-        fixture.Customize<TemporaryFileManager>(composer =>
-            composer.FromFactory<IFileSystem>(fs => new TemporaryFileManager(fs)));
+        fixture.Customize<RelativePath>(composer => composer.FromFactory<string>(path => path));
+        fixture.Customize<TemporaryFileManager>(composer => composer.FromFactory<IFileSystem>(fs => new TemporaryFileManager(fs)));
     }
 }

--- a/src/NexusMods.Paths/Extensions/StringExtensions.cs
+++ b/src/NexusMods.Paths/Extensions/StringExtensions.cs
@@ -1,12 +1,17 @@
+using System;
+using JetBrains.Annotations;
+
 namespace NexusMods.Paths.Extensions;
 
 /// <summary>
 /// Path related extensions tied to strings.
 /// </summary>
+[PublicAPI]
 public static class StringExtensions
 {
     /// <summary>
     /// Converts an existing path represented as a string to a <see cref="RelativePath"/>.
     /// </summary>
-    public static RelativePath ToRelativePath(this string s) => new(s);
+    [Obsolete($"Use implicit conversion or {nameof(RelativePath.FromUnsanitizedInput)}")]
+    public static RelativePath ToRelativePath(this string s) => s;
 }

--- a/src/NexusMods.Paths/RelativePath.cs
+++ b/src/NexusMods.Paths/RelativePath.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
 using NexusMods.Paths.Utilities;
 using Reloaded.Memory.Extensions;
@@ -116,10 +117,21 @@ public readonly struct RelativePath : IPath<RelativePath>, IEquatable<RelativePa
     /// Creates a relative path given a string.
     /// </summary>
     /// <param name="path">The relative path to use.</param>
-    public RelativePath(string path)
+    internal RelativePath(string path)
     {
         PathHelpers.DebugAssertIsSanitized(path, OS, isRelative: true);
         Path = path;
+    }
+
+    /// <summary>
+    /// Creates an unsafe relative path that hasn't been sanitized.
+    /// </summary>
+    /// <remarks>
+    /// This should only be used sparingly if you previously asserted that the path is sanitized.
+    /// </remarks>
+    public static RelativePath CreateUnsafe(string path)
+    {
+        return new RelativePath(path);
     }
 
     /// <summary>
@@ -327,7 +339,7 @@ public readonly struct RelativePath : IPath<RelativePath>, IEquatable<RelativePa
     public static implicit operator ReadOnlySpan<char>(RelativePath d) => d.Path;
 
     /// <summary/>
-    public static implicit operator RelativePath(string b) => new(b);
+    public static implicit operator RelativePath(string path) => FromUnsanitizedInput(path);
 
     /// <summary/>
     public static bool operator ==(RelativePath lhs, RelativePath rhs) => lhs.Equals(rhs);


### PR DESCRIPTION
https://github.com/Nexus-Mods/NexusMods.App/pull/2905 has showed that a public constructor of `RelativePath` can result in unforseen issues. The entire point of `RelativePath` and `AbsolutePath` is to provide a consistent abstraction over file paths. To achieve this consistency, paths have to be sanitized, otherwise many assumptions made in code aren't valid anymore.

Safety goes out the window with a public constructor that doesn't sanitized. I've added a `CreateUnsafe` method for the few cases where you want to skip sanitization because the input is already sanitized.