### PR TITLE
Remove `IOSInformation` argument from PathHelper

### DIFF
--- a/src/NexusMods.Paths.Benchmarks/Benchmarks/Pr42.cs
+++ b/src/NexusMods.Paths.Benchmarks/Benchmarks/Pr42.cs
@@ -26,7 +26,7 @@ public class Pr42 : IBenchmark
     [Benchmark]
     public string Current()
     {
-        return PathHelpers.JoinParts(Path1.AsSpan(), Path2.AsSpan(), _osInformation);
+        return PathHelpers.JoinParts(Path1.AsSpan(), Path2.AsSpan());
     }
 
     [Benchmark]
@@ -43,7 +43,7 @@ public class Pr42 : IBenchmark
             ? GC.AllocateUninitializedArray<char>(spanLength)
             : stackalloc char[spanLength];
 
-        var count = PathHelpers.JoinParts(buffer, left, right, os);
+        var count = PathHelpers.JoinParts(buffer, left, right);
         if (count == 0) return string.Empty;
         return buffer.ToString();
     }

--- a/src/NexusMods.Paths/AbsolutePath.cs
+++ b/src/NexusMods.Paths/AbsolutePath.cs
@@ -115,7 +115,7 @@ public readonly partial struct AbsolutePath : IEquatable<AbsolutePath>, IPath<Ab
     {
         PathHelpers.DebugAssertIsSanitized(directory);
         PathHelpers.DebugAssertIsSanitized(fileName);
-        PathHelpers.AssertIsRooted(directory, shouldBeRelative: false);
+        PathHelpers.AssertIsRooted(directory, shouldBeRooted: true);
 
         Directory = directory;
         FileName = fileName;

--- a/src/NexusMods.Paths/FileSystemAbstraction/BaseFileSystem.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/BaseFileSystem.cs
@@ -90,13 +90,16 @@ public abstract class BaseFileSystem : IFileSystem
         // "/opt/wine/drive_c"
 
         // Only supported on Linux and with the setting enabled
-        if (!OS.IsLinux || !_convertCrossPlatformPaths) return PathHelpers.Sanitize(input, OS, isRelative: false);
+        var sanitizedPath = PathHelpers.Sanitize(input);
+        if (!OS.IsLinux || !_convertCrossPlatformPaths) return sanitizedPath;
 
-        var sanitizedPathWindows = PathHelpers.Sanitize(input, OSInformation.FakeWindows, isRelative: false);
+        var pathRoot = PathHelpers.GetPathRoot(sanitizedPath);
+        if (pathRoot.RootType != PathRootType.Unix && pathRoot.RootType != PathRootType.DOS)
+            throw new NotSupportedException($"Root type `{pathRoot.RootType}` is not supported: `{sanitizedPath}`");
 
         var result = string.Create(
-            sanitizedPathWindows.Length,
-            sanitizedPathWindows,
+            sanitizedPath.Length,
+            sanitizedPath,
             (span, s) =>
             {
                 // C:/foo/bar -> /c/foo/bar

--- a/src/NexusMods.Paths/FileSystemAbstraction/RealFileSystem/DirectoriesEnumerator.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/RealFileSystem/DirectoriesEnumerator.cs
@@ -13,14 +13,12 @@ internal sealed class DirectoriesEnumerator : FileSystemEnumerator<string>
     private readonly string _startDirectory;
     private readonly string _pattern;
     private readonly EnumerationOptions _options;
-    private readonly IOSInformation _os;
 
-    public DirectoriesEnumerator(string directory, string pattern, EnumerationOptions options, IOSInformation os) : base(directory, options)
+    public DirectoriesEnumerator(string directory, string pattern, EnumerationOptions options) : base(directory, options)
     {
         _startDirectory = directory;
         _pattern = pattern;
         _options = options;
-        _os = os;
     }
 
     protected override void OnDirectoryFinished(ReadOnlySpan<char> directory)
@@ -31,7 +29,7 @@ internal sealed class DirectoriesEnumerator : FileSystemEnumerator<string>
 
     protected override string TransformEntry(ref FileSystemEntry entry)
     {
-        _currentDirectory ??= PathHelpers.Sanitize(entry.Directory, _os, isRelative: false);
-        return PathHelpers.Sanitize(entry.FileName, _os, isRelative: true);
+        _currentDirectory ??= PathHelpers.Sanitize(entry.Directory);
+        return PathHelpers.Sanitize(entry.FileName);
     }
 }

--- a/src/NexusMods.Paths/FileSystemAbstraction/RealFileSystem/FileSystem.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/RealFileSystem/FileSystem.cs
@@ -121,12 +121,12 @@ public partial class FileSystem : BaseFileSystem
     protected override IEnumerable<AbsolutePath> InternalEnumerateFiles(AbsolutePath directory, string pattern, bool recursive)
     {
         var options = GetSearchOptions(recursive);
-        using var enumerator = new FilesEnumerator(directory.GetFullPath(), pattern, options, OS);
+        using var enumerator = new FilesEnumerator(directory.GetFullPath(), pattern, options);
         while (enumerator.MoveNext())
         {
             var item = enumerator.Current;
             if (item.IsDirectory) continue;
-            yield return AbsolutePath.FromSanitizedFullPath(PathHelpers.JoinParts(enumerator.CurrentDirectory, item.FileName, OS), this);
+            yield return AbsolutePath.FromSanitizedFullPath(PathHelpers.JoinParts(enumerator.CurrentDirectory, item.FileName), this);
         }
     }
 
@@ -134,11 +134,11 @@ public partial class FileSystem : BaseFileSystem
     protected override IEnumerable<AbsolutePath> InternalEnumerateDirectories(AbsolutePath directory, string pattern, bool recursive)
     {
         var options = GetSearchOptions(recursive);
-        var enumerator = new DirectoriesEnumerator(directory.GetFullPath(), "*", options, OS);
+        var enumerator = new DirectoriesEnumerator(directory.GetFullPath(), "*", options);
         while (enumerator.MoveNext())
         {
             var item = enumerator.Current;
-            yield return AbsolutePath.FromSanitizedFullPath(PathHelpers.JoinParts(enumerator.CurrentDirectory, item, OS), this);
+            yield return AbsolutePath.FromSanitizedFullPath(PathHelpers.JoinParts(enumerator.CurrentDirectory, item), this);
         }
     }
 
@@ -146,13 +146,13 @@ public partial class FileSystem : BaseFileSystem
     protected override IEnumerable<IFileEntry> InternalEnumerateFileEntries(AbsolutePath directory, string pattern, bool recursive)
     {
         var options = GetSearchOptions(recursive);
-        var enumerator = new FilesEnumeratorEx(directory.GetFullPath(), pattern, options, OS);
+        var enumerator = new FilesEnumeratorEx(directory.GetFullPath(), pattern, options);
 
         while (enumerator.MoveNext())
         {
             var item = enumerator.Current;
             if (item.IsDirectory) continue;
-            yield return new FileEntry(this, AbsolutePath.FromSanitizedFullPath(PathHelpers.JoinParts(enumerator.CurrentDirectory, item.FileName, OS), this));
+            yield return new FileEntry(this, AbsolutePath.FromSanitizedFullPath(PathHelpers.JoinParts(enumerator.CurrentDirectory, item.FileName), this));
         }
     }
 

--- a/src/NexusMods.Paths/FileSystemAbstraction/RealFileSystem/FilesEnumerator.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/RealFileSystem/FilesEnumerator.cs
@@ -13,14 +13,12 @@ internal sealed class FilesEnumerator : FileSystemEnumerator<FilesEnumeratorEntr
     private readonly string _startDirectory;
     private readonly string _pattern;
     private readonly EnumerationOptions _options;
-    private readonly IOSInformation _os;
 
-    public FilesEnumerator(string directory, string pattern, EnumerationOptions options, IOSInformation os) : base(directory, options)
+    public FilesEnumerator(string directory, string pattern, EnumerationOptions options) : base(directory, options)
     {
         _startDirectory = directory;
         _pattern = pattern;
         _options = options;
-        _os = os;
     }
 
     protected override void OnDirectoryFinished(ReadOnlySpan<char> directory)
@@ -31,8 +29,8 @@ internal sealed class FilesEnumerator : FileSystemEnumerator<FilesEnumeratorEntr
 
     protected override FilesEnumeratorEntry TransformEntry(ref FileSystemEntry entry)
     {
-        _currentDirectory ??= PathHelpers.Sanitize(entry.Directory, _os, isRelative: false);
-        return new FilesEnumeratorEntry(PathHelpers.Sanitize(entry.FileName, _os, isRelative: true), entry.IsDirectory);
+        _currentDirectory ??= PathHelpers.Sanitize(entry.Directory);
+        return new FilesEnumeratorEntry(PathHelpers.Sanitize(entry.FileName), entry.IsDirectory);
     }
 }
 

--- a/src/NexusMods.Paths/FileSystemAbstraction/RealFileSystem/FilesEnumeratorEx.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/RealFileSystem/FilesEnumeratorEx.cs
@@ -14,14 +14,12 @@ internal sealed class FilesEnumeratorEx : FileSystemEnumerator<FilesEnumeratorEx
 
     private readonly string _pattern;
     private readonly EnumerationOptions _options;
-    private readonly IOSInformation _os;
 
-    public FilesEnumeratorEx(string directory, string pattern, EnumerationOptions options, IOSInformation os) : base(directory, options)
+    public FilesEnumeratorEx(string directory, string pattern, EnumerationOptions options) : base(directory, options)
     {
         _startDirectory = directory;
         _pattern = pattern;
         _options = options;
-        _os = os;
     }
 
     protected override void OnDirectoryFinished(ReadOnlySpan<char> directory)
@@ -32,8 +30,8 @@ internal sealed class FilesEnumeratorEx : FileSystemEnumerator<FilesEnumeratorEx
 
     protected override FilesEnumeratorExEntry TransformEntry(ref FileSystemEntry entry)
     {
-        _currentDirectory ??= PathHelpers.Sanitize(entry.Directory, _os, isRelative: false);
-        return new FilesEnumeratorExEntry(PathHelpers.Sanitize(entry.FileName, _os, isRelative: true), Size.FromLong(entry.Length), entry.LastWriteTimeUtc.DateTime, entry.IsDirectory);
+        _currentDirectory ??= PathHelpers.Sanitize(entry.Directory);
+        return new FilesEnumeratorExEntry(PathHelpers.Sanitize(entry.FileName), Size.FromLong(entry.Length), entry.LastWriteTimeUtc.DateTime, entry.IsDirectory);
     }
 }
 

--- a/src/NexusMods.Paths/PathRoot.cs
+++ b/src/NexusMods.Paths/PathRoot.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
+
+namespace NexusMods.Paths;
+
+/// <summary>
+/// Represents the root part of a path.
+/// </summary>
+[PublicAPI]
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+public readonly ref struct PathRoot
+{
+    /// <summary>
+    /// The root part.
+    /// </summary>
+    public readonly ReadOnlySpan<char> Span;
+
+    /// <summary>
+    /// The type.
+    /// </summary>
+    public readonly PathRootType RootType;
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public PathRoot(ReadOnlySpan<char> span, PathRootType rootType)
+    {
+        Span = span;
+        RootType = rootType;
+    }
+
+    /// <summary>
+    /// <see cref="PathRootType.DOS"/> root parts always have this length.
+    /// </summary>
+    internal const int DOSRootLength = 3;
+
+    /// <summary>
+    /// Minimum length of <see cref="PathRootType.UNC"/> root parts: <c>//A/</c>
+    /// </summary>
+    internal const int MinUNCRootLength = 4;
+
+    /// <summary>
+    /// Length of the DOS device prefix, either `//./` or `//?/`
+    /// </summary>
+    internal const int DOSDevicePrefixLength = 4;
+
+    /// <summary>
+    /// Minumum length of <see cref="PathRootType.DOSDeviceDrive"/> root parts: <c>//./C:/</c>
+    /// </summary>
+    internal const int DOSDeviceDriveRootLength = 7;
+
+    /// <summary>
+    /// Length of <see cref="PathRootType.DOSDeviceVolume"/> root parts: <c>//./Volume{b75e2c83-0000-0000-0000-602f00000000}/</c>
+    /// </summary>
+    internal const int DOSDeviceVolumeRootLength = 49;
+
+    /// <summary>
+    /// Prefix for <see cref="PathRootType.DOSDeviceVolume"/>.
+    /// </summary>
+    internal const string DOSDeviceVolumePrefix = "Volume{";
+}
+
+/// <summary>
+/// Path root types.
+/// </summary>
+/// <remarks>
+/// For Windows paths see https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats
+/// </remarks>
+[PublicAPI]
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+public enum PathRootType
+{
+    /// <summary>
+    /// None, the path isn't rooted.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// A Unix-style root.
+    /// </summary>
+    /// <example><c>/</c></example>
+    Unix = 1,
+
+    /// <summary>
+    /// A DOS root.
+    /// </summary>
+    /// <example><c>C:/</c></example>
+    DOS = 2,
+
+    /// <summary>
+    /// A UNC root.
+    /// </summary>
+    /// <example><c>//Server/</c></example>
+    UNC = 3,
+
+    /// <summary>
+    /// A DOS device path with a drive letter.
+    /// </summary>
+    /// <example><c>//./C:/</c></example>
+    /// <example><c>//?/C:/</c></example>
+    DOSDeviceDrive = 4,
+
+    /// <summary>
+    /// A DOS device path with a volume GUID.
+    /// </summary>
+    /// <example><c>//./Volume{b75e2c83-0000-0000-0000-602f00000000}/</c></example>
+    /// <example><c>//?/Volume{b75e2c83-0000-0000-0000-602f00000000}/</c></example>
+    DOSDeviceVolume = 5,
+}
+
+/// <summary>
+/// Extension methods for <see cref="PathRootType"/>.
+/// </summary>
+[PublicAPI]
+public static class PathRootTypeExtensions
+{
+    /// <summary>
+    /// Whether the root type is a Unix-style root.
+    /// </summary>
+    public static bool IsUnixRoot(this PathRootType rootType) => rootType == PathRootType.Unix;
+
+    /// <summary>
+    /// Whether the root type is a Windows-style root.
+    /// </summary>
+    public static bool IsWindowsRoot(this PathRootType rootType) => rootType switch
+    {
+        PathRootType.DOS or PathRootType.UNC or PathRootType.DOSDeviceDrive or PathRootType.DOSDeviceVolume => true,
+        _ => false
+    };
+}

--- a/src/NexusMods.Paths/PathRoot.cs
+++ b/src/NexusMods.Paths/PathRoot.cs
@@ -22,6 +22,11 @@ public readonly ref struct PathRoot
     public readonly PathRootType RootType;
 
     /// <summary>
+    /// Length of the root part.
+    /// </summary>
+    public int Length => Span.Length;
+
+    /// <summary>
     /// Constructor.
     /// </summary>
     public PathRoot(ReadOnlySpan<char> span, PathRootType rootType)
@@ -46,7 +51,7 @@ public readonly ref struct PathRoot
     internal const int DOSDevicePrefixLength = 4;
 
     /// <summary>
-    /// Minumum length of <see cref="PathRootType.DOSDeviceDrive"/> root parts: <c>//./C:/</c>
+    /// Minimum length of <see cref="PathRootType.DOSDeviceDrive"/> root parts: <c>//./C:/</c>
     /// </summary>
     internal const int DOSDeviceDriveRootLength = 7;
 
@@ -59,6 +64,16 @@ public readonly ref struct PathRoot
     /// Prefix for <see cref="PathRootType.DOSDeviceVolume"/>.
     /// </summary>
     internal const string DOSDeviceVolumePrefix = "Volume{";
+
+    /// <summary>
+    /// Volume separator character on Windows.
+    /// </summary>
+    /// <remarks>
+    /// This character is used to separate the drive character of a volume, from the rest
+    /// of the path. The path "C:/" has the drive character 'C', the volume separator character
+    /// ':' and finally the root directory name '/'.
+    /// </remarks>
+    public const char WindowsVolumeSeparatorChar = ':';
 }
 
 /// <summary>

--- a/src/NexusMods.Paths/RelativePath.cs
+++ b/src/NexusMods.Paths/RelativePath.cs
@@ -43,12 +43,12 @@ public readonly struct RelativePath : IPath<RelativePath>, IEquatable<RelativePa
     public RelativePath FileName => Name;
 
     /// <inheritdoc />
-    public RelativePath Name => new(PathHelpers.GetFileName(Path, OS).ToString());
+    public RelativePath Name => new(PathHelpers.GetFileName(Path).ToString());
 
     /// <summary>
     /// Amount of directories contained within this relative path.
     /// </summary>
-    public int Depth => PathHelpers.GetDirectoryDepth(Path, OS);
+    public int Depth => PathHelpers.GetDirectoryDepth(Path);
 
     /// <summary>
     /// Traverses one directory up.
@@ -57,7 +57,7 @@ public readonly struct RelativePath : IPath<RelativePath>, IEquatable<RelativePa
     {
         get
         {
-            var directoryName = PathHelpers.GetDirectoryName(Path, OS);
+            var directoryName = PathHelpers.GetDirectoryName(Path);
             return directoryName.IsEmpty ? Empty : new RelativePath(directoryName.ToString());
         }
     }
@@ -108,7 +108,7 @@ public readonly struct RelativePath : IPath<RelativePath>, IEquatable<RelativePa
     {
         get
         {
-            var topParent = PathHelpers.GetTopParent(Path, OS);
+            var topParent = PathHelpers.GetTopParent(Path);
             return topParent.IsEmpty ? Empty : new RelativePath(topParent.ToString());
         }
     }
@@ -119,7 +119,8 @@ public readonly struct RelativePath : IPath<RelativePath>, IEquatable<RelativePa
     /// <param name="path">The relative path to use.</param>
     internal RelativePath(string path)
     {
-        PathHelpers.DebugAssertIsSanitized(path, OS);
+        PathHelpers.DebugAssertIsSanitized(path);
+        PathHelpers.AssertIsRooted(path, shouldBeRelative: true);
         Path = path;
     }
 
@@ -140,7 +141,7 @@ public readonly struct RelativePath : IPath<RelativePath>, IEquatable<RelativePa
     /// <param name="path"></param>
     public static RelativePath FromUnsanitizedInput(ReadOnlySpan<char> path)
     {
-        return new RelativePath(PathHelpers.Sanitize(path, OS, isRelative: true));
+        return new RelativePath(PathHelpers.Sanitize(path));
     }
 
     /// <summary>
@@ -174,7 +175,7 @@ public readonly struct RelativePath : IPath<RelativePath>, IEquatable<RelativePa
     [Pure]
     public RelativePath Join(RelativePath other)
     {
-        return new RelativePath(PathHelpers.JoinParts(Path, other.Path, OS));
+        return new RelativePath(PathHelpers.JoinParts(Path, other.Path));
     }
     
     /// <summary>
@@ -274,7 +275,7 @@ public readonly struct RelativePath : IPath<RelativePath>, IEquatable<RelativePa
     /// <inheritdoc />
     public bool InFolder(RelativePath other)
     {
-        return PathHelpers.InFolder(Path, other.Path, OS);
+        return PathHelpers.InFolder(Path, other.Path);
     }
 
     /// <summary>
@@ -283,7 +284,7 @@ public readonly struct RelativePath : IPath<RelativePath>, IEquatable<RelativePa
     /// <param name="numDirectories">Number of directories to drop.</param>
     public RelativePath DropFirst(int numDirectories = 1)
     {
-        var res = PathHelpers.DropParents(Path, numDirectories, OS);
+        var res = PathHelpers.DropParents(Path, numDirectories);
         return res.IsEmpty ? Empty : new RelativePath(res.ToString());
     }
 
@@ -301,7 +302,7 @@ public readonly struct RelativePath : IPath<RelativePath>, IEquatable<RelativePa
         if (other.Length == 0) return this;
         if (basePath.Path == Path) return Empty;
 
-        var res = PathHelpers.RelativeTo(Path, other, OS);
+        var res = PathHelpers.RelativeTo(Path, other);
         if (!res.IsEmpty) return new RelativePath(res.ToString());
 
         ThrowHelpers.PathException($"Path '{Path}' is not relative to '{other}'");
@@ -314,7 +315,7 @@ public readonly struct RelativePath : IPath<RelativePath>, IEquatable<RelativePa
     #region Equals & GetHashCode
 
     /// <inheritdoc />
-    public bool Equals(RelativePath other) => PathHelpers.PathEquals(Path, other.Path, OS);
+    public bool Equals(RelativePath other) => PathHelpers.PathEquals(Path, other.Path);
 
     /// <inheritdoc />
     public override bool Equals(object? obj)
@@ -348,7 +349,7 @@ public readonly struct RelativePath : IPath<RelativePath>, IEquatable<RelativePa
     public static bool operator !=(RelativePath lhs, RelativePath rhs) => !(lhs == rhs);
 
     /// <inheritdoc />
-    public int CompareTo(RelativePath other) => PathHelpers.Compare(Path, other.Path, OS);
+    public int CompareTo(RelativePath other) => PathHelpers.Compare(Path, other.Path);
 }
 
 /// <summary>

--- a/src/NexusMods.Paths/RelativePath.cs
+++ b/src/NexusMods.Paths/RelativePath.cs
@@ -120,7 +120,7 @@ public readonly struct RelativePath : IPath<RelativePath>, IEquatable<RelativePa
     internal RelativePath(string path)
     {
         PathHelpers.DebugAssertIsSanitized(path);
-        PathHelpers.AssertIsRooted(path, shouldBeRelative: true);
+        PathHelpers.AssertIsRooted(path, shouldBeRooted: false);
         Path = path;
     }
 

--- a/src/NexusMods.Paths/Utilities/PathHelpers.cs
+++ b/src/NexusMods.Paths/Utilities/PathHelpers.cs
@@ -64,16 +64,16 @@ public static class PathHelpers
     }
 
     /// <summary>
-    /// Asserts whether the path is rooted depending on <paramref name="shouldBeRelative"/>.
+    /// Asserts whether the path is rooted depending on <paramref name="shouldBeRooted"/>.
     /// </summary>
     /// <exception cref="PathException">Thrown when relative paths are rooted or absolute paths aren't rooted.</exception>
-    public static void AssertIsRooted(ReadOnlySpan<char> input, bool shouldBeRelative)
+    public static void AssertIsRooted(ReadOnlySpan<char> input, bool shouldBeRooted)
     {
         if (input.IsEmpty) return;
 
         var isRooted = IsRooted(input);
-        if (isRooted && shouldBeRelative) throw new PathException($"Relative paths can't be rooted: `{input.ToString()}`");
-        if (!isRooted && !shouldBeRelative) throw new PathException($"Absolute paths must be rooted: `{input.ToString()}`");
+        if (isRooted && !shouldBeRooted) throw new PathException($"Relative paths can't be rooted: `{input.ToString()}`");
+        if (!isRooted && shouldBeRooted) throw new PathException($"Absolute paths must be rooted: `{input.ToString()}`");
     }
 
     /// <summary>

--- a/tests/NexusMods.Paths.Tests/FileSystem/BaseFileSystemTests.cs
+++ b/tests/NexusMods.Paths.Tests/FileSystem/BaseFileSystemTests.cs
@@ -67,21 +67,6 @@ public class BaseFileSystemTests
         result.Should().BeEquivalentTo(contents);
     }
 
-    [Theory]
-    [InlineData("C:/", "/c")]
-    [InlineData("C:/foo/bar", "/c/foo/bar")]
-    public void Test_ConvertCrossPlatformPath(string input, string output)
-    {
-        var fs = new InMemoryFileSystem(OSInformation.FakeUnix)
-            .CreateOverlayFileSystem(
-            new Dictionary<AbsolutePath, AbsolutePath>(),
-            new Dictionary<KnownPath, AbsolutePath>(),
-            true);
-
-        var path = fs.FromUnsanitizedFullPath(input);
-        path.GetFullPath().Should().Be(output);
-    }
-
     [Fact]
     public void Test_KnownPathMappings()
     {
@@ -166,7 +151,7 @@ public class BaseFileSystemTests
             .Select(iDriveLetter =>
             {
                 var driveLetter = (char)iDriveLetter;
-                var originalPath = fs.FromUnsanitizedDirectoryAndFileName("/", driveLetter.ToString());
+                var originalPath = fs.FromUnsanitizedDirectoryAndFileName($"{char.ToUpper(driveLetter)}:/", "");
                 var newPath = rootDirectory / Guid.NewGuid().ToString("D");
                 return (originalPath, newPath);
             }).ToDictionary(x => x.originalPath, x => x.newPath);

--- a/tests/NexusMods.Paths.Tests/PathHelperTests.cs
+++ b/tests/NexusMods.Paths.Tests/PathHelperTests.cs
@@ -6,6 +6,39 @@ namespace NexusMods.Paths.Tests;
 
 public class PathHelperTests
 {
+    [Theory]
+    [MemberData(nameof(TestData_GetPathRoot))]
+    public void Test_GetPathRoot(string input, string expectedRootPart, PathRootType expectedRootType)
+    {
+        var pathRoot = PathHelpers.GetPathRoot(input);
+        pathRoot.Span.ToString().Should().Be(expectedRootPart);
+        pathRoot.RootType.Should().Be(expectedRootType);
+    }
+
+    public static TheoryData<string, string, PathRootType> TestData_GetPathRoot()
+    {
+        return new TheoryData<string, string, PathRootType>
+        {
+            { "", "", PathRootType.None },
+            { "/", "/", PathRootType.Unix },
+            { "/foo", "/", PathRootType.Unix },
+            { "C:/", "C:/", PathRootType.DOS },
+            { "C:/foo", "C:/", PathRootType.DOS },
+            { "//A/" , "//A/", PathRootType.UNC },
+            { "//A/foo" , "//A/", PathRootType.UNC },
+            { "//Server/" , "//Server/", PathRootType.UNC },
+            { "//Server/foo" , "//Server/", PathRootType.UNC },
+            { "//./C:/", "//./C:/", PathRootType.DOSDeviceDrive },
+            { "//?/C:/", "//?/C:/", PathRootType.DOSDeviceDrive },
+            { "//./C:/foo", "//./C:/", PathRootType.DOSDeviceDrive },
+            { "//?/C:/foo", "//?/C:/", PathRootType.DOSDeviceDrive },
+            { "//./Volume{b75e2c83-0000-0000-0000-602f00000000}/", "//./Volume{b75e2c83-0000-0000-0000-602f00000000}/", PathRootType.DOSDeviceVolume },
+            { "//?/Volume{b75e2c83-0000-0000-0000-602f00000000}/", "//?/Volume{b75e2c83-0000-0000-0000-602f00000000}/", PathRootType.DOSDeviceVolume },
+            { "//./Volume{b75e2c83-0000-0000-0000-602f00000000}/foo", "//./Volume{b75e2c83-0000-0000-0000-602f00000000}/", PathRootType.DOSDeviceVolume },
+            { "//?/Volume{b75e2c83-0000-0000-0000-602f00000000}/foo", "//?/Volume{b75e2c83-0000-0000-0000-602f00000000}/", PathRootType.DOSDeviceVolume },
+        };
+    }
+
     private static IOSInformation CreateOSInformation(bool isUnix)
     {
         return isUnix ? OSInformation.FakeUnix : OSInformation.FakeWindows;

--- a/tests/NexusMods.Paths.Tests/PathHelperTests.cs
+++ b/tests/NexusMods.Paths.Tests/PathHelperTests.cs
@@ -7,6 +7,40 @@ namespace NexusMods.Paths.Tests;
 public class PathHelperTests
 {
     [Theory]
+    [InlineData("", "")]
+    [InlineData("foo", "foo")]
+    [InlineData("foo ", "foo")]
+    [InlineData("foo/bar", "foo/bar")]
+    [InlineData("foo/bar/", "foo/bar")]
+    [InlineData("foo/bar/ ", "foo/bar")]
+    [InlineData(@"foo\bar", "foo/bar")]
+    [InlineData(@"foo\bar\", "foo/bar")]
+    [InlineData("/", "/")]
+    [InlineData("//", "/")]
+    [InlineData("/foo", "/foo")]
+    [InlineData("/foo/", "/foo")]
+    [InlineData("/foo//bar//", "/foo/bar")]
+    [InlineData(@"C:\", "C:/")]
+    [InlineData(@"C:\foo", "C:/foo")]
+    [InlineData(@"C:\foo\", "C:/foo")]
+    [InlineData(@"\\Server\\foo", "//Server/foo")]
+    [InlineData(@"\\.\C:\foo", "//./C:/foo")]
+    [InlineData(@"\\?\C:\foo", "//?/C:/foo")]
+    [InlineData(@"\\.\Volume{b75e2c83-0000-0000-0000-602f00000000}\foo", "//./Volume{b75e2c83-0000-0000-0000-602f00000000}/foo")]
+    [InlineData(@"\\?\Volume{b75e2c83-0000-0000-0000-602f00000000}\foo", "//?/Volume{b75e2c83-0000-0000-0000-602f00000000}/foo")]
+    public void Test_Sanitize(string input, string? expected)
+    {
+        var actual = PathHelpers.Sanitize(input);
+        actual.Should().Be(expected);
+
+        var isSanitized = PathHelpers.IsSanitized(actual);
+        isSanitized.Should().BeTrue(because: "input was just sanitized");
+
+        var again = PathHelpers.Sanitize(actual);
+        again.Should().Be(actual, because: "already sanitized, no changes should be made");
+    }
+
+    [Theory]
     [MemberData(nameof(TestData_GetPathRoot))]
     public void Test_GetPathRoot(string input, string expectedRootPart, PathRootType expectedRootType)
     {
@@ -20,6 +54,8 @@ public class PathHelperTests
         return new TheoryData<string, string, PathRootType>
         {
             { "", "", PathRootType.None },
+            { "foo", "", PathRootType.None },
+            { "foo/bar", "", PathRootType.None },
             { "/", "/", PathRootType.Unix },
             { "/foo", "/", PathRootType.Unix },
             { "C:/", "C:/", PathRootType.DOS },
@@ -45,75 +81,31 @@ public class PathHelperTests
     }
 
     [Theory]
-    [InlineData(true, false, "", true)]
-    [InlineData(true, false, "/", true)]
-    [InlineData(true, false, "/foo", true)]
-    [InlineData(true, false, "/foo/bar", true)]
-    [InlineData(true, false, "/foo/bar.txt", true)]
-    [InlineData(true, true, "foo", true)]
-    [InlineData(true, true, "foo/bar", true)]
-    [InlineData(true, true,"foo/", false)]
-    [InlineData(true, true,"foo/bar/", false)]
-    [InlineData(true, false, "/foo/", false)]
-    [InlineData(true, false, "/            ", false)]
-    [InlineData(false, false, "", true)]
-    [InlineData(false, false, "C:/", true)]
-    [InlineData(false, false,"C:/foo", true)]
-    [InlineData(false, false, "C:/foo/bar", true)]
-    [InlineData(false, false, "C:/foo/bar.txt", true)]
-    [InlineData(false, true,"foo", true)]
-    [InlineData(false, true,"foo/bar", true)]
-    [InlineData(false, true, "foo/", false)]
-    [InlineData(false, false,"foo/bar/", false)]
-    [InlineData(false, false,"C:/foo/", false)]
-    [InlineData(false, false,"C:\\", false)]
-    [InlineData(false, false,"C:\\foo", false)]
-    [InlineData(false, false,"C:\\foo\\", false)]
-    [InlineData(false, false,"C:\\\\foo", false)]
-    [InlineData(false, true,"foo\\bar", false)]
-    public void Test_IsSanitized(bool isUnix, bool isRelative, string path, bool expected)
+    [InlineData("", true)]
+    [InlineData("/", true)]
+    [InlineData("/foo", true)]
+    [InlineData("/foo/bar", true)]
+    [InlineData("/foo/bar.txt", true)]
+    [InlineData("foo", true)]
+    [InlineData("foo/bar", true)]
+    [InlineData("foo/", false)]
+    [InlineData("foo/bar/", false)]
+    [InlineData("/foo/", false)]
+    [InlineData( "/            ", false)]
+    [InlineData( "C:/", true)]
+    [InlineData("C:/foo", true)]
+    [InlineData("C:/foo/bar", true)]
+    [InlineData("C:/foo/bar.txt", true)]
+    [InlineData("C:/foo/", false)]
+    [InlineData("C:\\", false)]
+    [InlineData("C:\\foo", false)]
+    [InlineData("C:\\foo\\", false)]
+    [InlineData("C:\\\\foo", false)]
+    [InlineData("foo\\bar", false)]
+    public void Test_IsSanitized(string input, bool expected)
     {
-        var actual = PathHelpers.IsSanitized(path, CreateOSInformation(isUnix), isRelative);
+        var actual = PathHelpers.IsSanitized(input);
         actual.Should().Be(expected);
-    }
-
-    [Theory]
-    [InlineData(true, "/foo/bar", false)]
-    [InlineData(true, "foo/bar", true)]
-    [InlineData(false, "C:/foo/bar", false)]
-    [InlineData(false, "foo/bar", true)]
-    public void Test_IsSanitized_Relative(bool isUnix, string path, bool expected)
-    {
-        var actual = PathHelpers.IsSanitized(path, CreateOSInformation(isUnix), isRelative: true);
-        actual.Should().Be(expected);
-    }
-
-    [Theory]
-    [InlineData(true, "", "")]
-    [InlineData(true, "/", "/")]
-    [InlineData(true, "/foo/", "/foo")]
-    [InlineData(true, "/foo\\bar", "/foo/bar")]
-    [InlineData(false, "", "")]
-    [InlineData(false, "C:/", "C:/")]
-    [InlineData(false, "C:\\", "C:/")]
-    [InlineData(false, "C:\\foo", "C:/foo")]
-    [InlineData(false, "C:\\foo\\", "C:/foo")]
-    [InlineData(false, "C:\\\\foo", "C:/foo")]
-    [InlineData(false, "C:\\\\\\\\\\foo\\\\\\bar\\\\\\baz\\\\\\\\", "C:/foo/bar/baz")]
-    public void Test_Sanitize(bool isUnix, string input, string expectedOutput)
-    {
-        var actualOutput = PathHelpers.Sanitize(input, CreateOSInformation(isUnix), isRelative: false);
-        actualOutput.Should().Be(expectedOutput);
-    }
-
-    [Theory]
-    [InlineData(true, true, "/foo")]
-    [InlineData(false, true, "C:/foo")]
-    [InlineData(true, false, "foo")]
-    public void Test_SanitizeException(bool isUnix, bool isRelative, string input)
-    {
-        var act = () => PathHelpers.Sanitize(input, CreateOSInformation(isUnix), isRelative);
-        act.Should().ThrowExactly<PathException>();
     }
 
     [Theory]
@@ -130,41 +122,41 @@ public class PathHelperTests
     }
 
     [Theory]
-    [InlineData(true, "", "", true)]
-    [InlineData(true,"foo", "", false)]
-    [InlineData(true,"", "foo", false)]
-    [InlineData(true,"foo", "foo", true)]
-    [InlineData(true,"foo", "FOO", true)]
-    [InlineData(true,"/foo", "/foo", true)]
-    [InlineData(true,"/foo", "/FOO", true)]
-    [InlineData(false, "C:/", "C:/", true)]
-    [InlineData(false, "C:/foo", "C:/foo", true)]
-    [InlineData(false, "C:/foo", "C:/FOO", true)]
-    public void Test_Equals(bool isUnix, string left, string right, bool expected)
+    [InlineData("", "", true)]
+    [InlineData("foo", "", false)]
+    [InlineData("", "foo", false)]
+    [InlineData("foo", "foo", true)]
+    [InlineData("foo", "FOO", true)]
+    [InlineData("/foo", "/foo", true)]
+    [InlineData("/foo", "/FOO", true)]
+    [InlineData("C:/", "C:/", true)]
+    [InlineData("C:/foo", "C:/foo", true)]
+    [InlineData("C:/foo", "C:/FOO", true)]
+    public void Test_Equals(string left, string right, bool expected)
     {
-        var actual = PathHelpers.PathEquals(left, right, CreateOSInformation(isUnix));
+        var actual = PathHelpers.PathEquals(left, right);
         actual.Should().Be(expected);
     }
 
     [Theory]
-    [InlineData(true, "", "", 0)]
-    [InlineData(true, "", "foo", -1)]
-    [InlineData(true, "foo", "", 1)]
-    [InlineData(true, "foo", "foo", 0)]
-    [InlineData(true, "foo", "FOO", 0)]
-    [InlineData(true, "/foo", "/foo", 0)]
-    [InlineData(true, "/foo", "/FOO", 0)]
-    [InlineData(true, "/FOO", "/foo", 0)]
-    [InlineData(true, "/foo", "/bar", 1)]
-    [InlineData(true, "/bar", "/foo", -1)]
-    [InlineData(false, "C:/foo", "C:/foo", 0)]
-    [InlineData(false, "C:/foo", "C:/FOO", 0)]
-    [InlineData(false, "C:/FOO", "C:/foo", 0)]
-    [InlineData(false, "C:/foo", "C:/bar", 1)]
-    [InlineData(false, "C:/bar", "C:/foo", -1)]
-    public void Test_Compare(bool isUnix, string left, string right, int expected)
+    [InlineData("", "", 0)]
+    [InlineData("", "foo", -1)]
+    [InlineData("foo", "", 1)]
+    [InlineData("foo", "foo", 0)]
+    [InlineData("foo", "FOO", 0)]
+    [InlineData("/foo", "/foo", 0)]
+    [InlineData("/foo", "/FOO", 0)]
+    [InlineData("/FOO", "/foo", 0)]
+    [InlineData("/foo", "/bar", 1)]
+    [InlineData("/bar", "/foo", -1)]
+    [InlineData("C:/foo", "C:/foo", 0)]
+    [InlineData("C:/foo", "C:/FOO", 0)]
+    [InlineData("C:/FOO", "C:/foo", 0)]
+    [InlineData("C:/foo", "C:/bar", 1)]
+    [InlineData("C:/bar", "C:/foo", -1)]
+    public void Test_Compare(string left, string right, int expected)
     {
-        var actual = PathHelpers.Compare(left, right, CreateOSInformation(isUnix));
+        var actual = PathHelpers.Compare(left, right);
         actual = actual switch
         {
             0 => 0,
@@ -202,98 +194,73 @@ public class PathHelperTests
     }
 
     [Theory]
-    [InlineData(true, "/", 1)]
-    [InlineData(true, "/foo", 1)]
-    [InlineData(true, "/foo/", 1)]
-    [InlineData(true, "/foo/bar", 1)]
-    [InlineData(true, "foo", -1)]
-    [InlineData(true, "foo/bar", -1)]
-    [InlineData(false, "C:/", 3)]
-    [InlineData(false, "C:/foo", 3)]
-    [InlineData(false, "C:/foo/", 3)]
-    [InlineData(false, "C:/foo/bar", 3)]
-    [InlineData(false, "foo", -1)]
-    [InlineData(false, "foo/bar", -1)]
-    public void Test_GetRootLength(bool isUnix, string path, int expectedRootLength)
+    [InlineData("/", 1)]
+    [InlineData("/foo", 1)]
+    [InlineData("/foo/", 1)]
+    [InlineData("/foo/bar", 1)]
+    [InlineData("foo", -1)]
+    [InlineData("foo/bar", -1)]
+    [InlineData("C:/", 3)]
+    [InlineData("C:/foo", 3)]
+    [InlineData("C:/foo/", 3)]
+    [InlineData("C:/foo/bar", 3)]
+    public void Test_GetRootLength(string path, int expectedRootLength)
     {
-        var actualRootLength = PathHelpers.GetRootLength(path, CreateOSInformation(isUnix));
+        var actualRootLength = PathHelpers.GetRootLength(path);
         actualRootLength.Should().Be(expectedRootLength);
     }
 
     [Theory]
-    [InlineData(true, "/", true)]
-    [InlineData(true, "/foo", true)]
-    [InlineData(true, "/foo/", true)]
-    [InlineData(true, "/foo/bar", true)]
-    [InlineData(true, "foo", false)]
-    [InlineData(true, "foo/bar", false)]
-    [InlineData(false, "C:/", true)]
-    [InlineData(false, "C:/foo", true)]
-    [InlineData(false, "C:/foo/", true)]
-    [InlineData(false, "C:/foo/bar", true)]
-    [InlineData(false, "foo", false)]
-    [InlineData(false, "foo/bar", false)]
-    public void Test_IsRooted(bool isUnix, string path, bool expectedResult)
+    [InlineData("/", true)]
+    [InlineData("/foo", true)]
+    [InlineData("/foo/", true)]
+    [InlineData("/foo/bar", true)]
+    [InlineData("foo", false)]
+    [InlineData("foo/bar", false)]
+    [InlineData("C:/", true)]
+    [InlineData("C:/foo", true)]
+    [InlineData("C:/foo/", true)]
+    [InlineData("C:/foo/bar", true)]
+    public void Test_IsRooted(string path, bool expectedResult)
     {
-        var actualResult = PathHelpers.IsRooted(path, CreateOSInformation(isUnix));
+        var actualResult = PathHelpers.IsRooted(path);
         actualResult.Should().Be(expectedResult);
     }
 
     [Theory]
-    [InlineData(true, "/", "/")]
-    [InlineData(true, "/foo", "/")]
-    [InlineData(true, "/foo/", "/")]
-    [InlineData(true, "/foo/bar", "/")]
-    [InlineData(true, "foo", "")]
-    [InlineData(true, "foo/bar", "")]
-    [InlineData(false, "C:/", "C:/")]
-    [InlineData(false, "C:/foo", "C:/")]
-    [InlineData(false, "C:/foo/", "C:/")]
-    [InlineData(false, "C:/foo/bar", "C:/")]
-    [InlineData(false, "foo", "")]
-    [InlineData(false, "foo/bar", "")]
-    public void Test_GetRootedPart(bool isUnix, string path, string expectedRootPart)
+    [InlineData( "/", true)]
+    [InlineData( "/foo", false)]
+    [InlineData( "/foo/", false)]
+    [InlineData( "/foo/bar", false)]
+    [InlineData( "foo", false)]
+    [InlineData( "foo/bar", false)]
+    [InlineData( "C:/", true)]
+    [InlineData( "C:/foo", false)]
+    [InlineData( "C:/foo/", false)]
+    [InlineData( "C:/foo/bar", false)]
+    public void Test_IsRootDirectory(string path, bool expected)
     {
-        var actualRootPart = PathHelpers.GetRootPart(path, CreateOSInformation(isUnix)).ToString();
-        actualRootPart.Should().Be(expectedRootPart);
-    }
-
-    [Theory]
-    [InlineData(true, "/", true)]
-    [InlineData(true, "/foo", false)]
-    [InlineData(true, "/foo/", false)]
-    [InlineData(true, "/foo/bar", false)]
-    [InlineData(true, "foo", false)]
-    [InlineData(true, "foo/bar", false)]
-    [InlineData(false, "C:/", true)]
-    [InlineData(false, "C:/foo", false)]
-    [InlineData(false, "C:/foo/", false)]
-    [InlineData(false, "C:/foo/bar", false)]
-    [InlineData(false, "foo", false)]
-    [InlineData(false, "foo/bar", false)]
-    public void Test_IsRootDirectory(bool isUnix, string path, bool expected)
-    {
-        var actual = PathHelpers.IsRootDirectory(path, CreateOSInformation(isUnix));
+        var actual = PathHelpers.IsRootDirectory(path);
         actual.Should().Be(expected);
     }
 
     [Theory]
-    [InlineData(true, "/", "foo", "/foo")]
-    [InlineData(true, "/foo", "bar", "/foo/bar")]
-    [InlineData(true, "foo", "bar", "foo/bar")]
-    [InlineData(true, "/", "foo/bar", "/foo/bar")]
-    [InlineData(true, "", "foo", "foo")]
-    [InlineData(true, "foo", "", "foo")]
-    [InlineData(false, "C:/", "foo", "C:/foo")]
-    [InlineData(false, "C:/foo", "bar", "C:/foo/bar")]
-    [InlineData(false, "C:/", "foo/bar", "C:/foo/bar")]
-    [InlineData(false, "", "", "")]
-    public void Test_JoinParts(bool isUnix, string left, string right, string expectedResult)
+    [InlineData( "/", "foo", "/foo")]
+    [InlineData( "/foo", "bar", "/foo/bar")]
+    [InlineData( "foo", "bar", "foo/bar")]
+    [InlineData( "/", "foo/bar", "/foo/bar")]
+    [InlineData( "", "foo", "foo")]
+    [InlineData( "foo", "", "foo")]
+    [InlineData( "C:/", "foo", "C:/foo")]
+    [InlineData( "C:/foo", "bar", "C:/foo/bar")]
+    [InlineData( "C:/", "foo/bar", "C:/foo/bar")]
+    [InlineData( "", "", "")]
+    public void Test_JoinParts(string left, string right, string expectedResult)
     {
-        var actualResult1 = PathHelpers.JoinParts(left, right, CreateOSInformation(isUnix));
+        var actualResult1 = PathHelpers.JoinParts(left, right);
         actualResult1.Should().Be(expectedResult);
 
-        var actualResult2 = PathHelpers.JoinParts(left.AsSpan(), right.AsSpan(), CreateOSInformation(isUnix));
+        var actualResult2 = PathHelpers.JoinParts(left.AsSpan(), right.AsSpan());
         actualResult2.Should().Be(expectedResult);
     }
 
@@ -321,18 +288,18 @@ public class PathHelperTests
     }
 
     [Theory]
-    [InlineData(true, "", "")]
-    [InlineData(true, "foo", "foo")]
-    [InlineData(true, "foo/bar", "bar")]
-    [InlineData(true, "/", "")]
-    [InlineData(true, "/foo", "foo")]
-    [InlineData(true, "/foo/bar", "bar")]
-    [InlineData(false, "C:/", "")]
-    [InlineData(false, "C:/foo", "foo")]
-    [InlineData(false, "C:/foo/bar", "bar")]
-    public void Test_GetFileName(bool isUnix, string path, string expectedFileName)
+    [InlineData( "", "")]
+    [InlineData( "foo", "foo")]
+    [InlineData( "foo/bar", "bar")]
+    [InlineData( "/", "")]
+    [InlineData( "/foo", "foo")]
+    [InlineData( "/foo/bar", "bar")]
+    [InlineData( "C:/", "")]
+    [InlineData( "C:/foo", "foo")]
+    [InlineData( "C:/foo/bar", "bar")]
+    public void Test_GetFileName(string path, string expectedFileName)
     {
-        var actualFileName = PathHelpers.GetFileName(path, CreateOSInformation(isUnix)).ToString();
+        var actualFileName = PathHelpers.GetFileName(path).ToString();
         actualFileName.Should().Be(expectedFileName);
     }
 
@@ -359,127 +326,128 @@ public class PathHelperTests
     }
 
     [Theory]
-    [InlineData(true, "", 0)]
-    [InlineData(true, "foo.txt", 0)]
-    [InlineData(true, "foo/bar.txt", 1)]
-    [InlineData(true, "/", 1)]
-    [InlineData(true, "/foo.txt", 1)]
-    [InlineData(true, "/foo/bar.txt", 2)]
-    [InlineData(false, "C:/", 1)]
-    [InlineData(false, "C:/foo.txt", 1)]
-    [InlineData(false, "C:/foo/bar.txt", 2)]
-    public void Test_GetDirectoryDepth(bool isUnix, string input, int expectedDepth)
+    [InlineData("", 0)]
+    [InlineData("foo.txt", 0)]
+    [InlineData("foo/bar.txt", 1)]
+    [InlineData("/", 1)]
+    [InlineData("/foo.txt", 1)]
+    [InlineData("/foo/bar.txt", 2)]
+    [InlineData("C:/", 1)]
+    [InlineData("C:/foo.txt", 1)]
+    [InlineData("C:/foo/bar.txt", 2)]
+    [InlineData("//Server/foo/bar.txt", 2)]
+    [InlineData("//./C:/foo/bar", 2)]
+    public void Test_GetDirectoryDepth(string input, int expectedDepth)
     {
-        var actualDepth = PathHelpers.GetDirectoryDepth(input, CreateOSInformation(isUnix));
+        var actualDepth = PathHelpers.GetDirectoryDepth(input);
         actualDepth.Should().Be(expectedDepth);
     }
 
     [Theory]
-    [InlineData(true, "/", "/")]
-    [InlineData(true, "/foo", "/")]
-    [InlineData(true, "/foo/bar", "/foo")]
-    [InlineData(true, "", "")]
-    [InlineData(true, "foo", "")]
-    [InlineData(true, "foo/bar", "foo")]
-    [InlineData(false, "C:/", "C:/")]
-    [InlineData(false, "C:/foo", "C:/")]
-    [InlineData(false, "C:/foo/bar", "C:/foo")]
-    [InlineData(false, "", "")]
-    [InlineData(false, "foo", "")]
-    [InlineData(false, "foo/bar", "foo")]
-    public void Test_GetDirectoryName(bool isUnix, string input, string expectedOutput)
+    [InlineData("/", "/")]
+    [InlineData("/foo", "/")]
+    [InlineData("/foo/bar", "/foo")]
+    [InlineData("", "")]
+    [InlineData("foo", "")]
+    [InlineData("foo/bar", "foo")]
+    [InlineData("C:/", "C:/")]
+    [InlineData("C:/foo", "C:/")]
+    [InlineData("C:/foo/bar", "C:/foo")]
+    public void Test_GetDirectoryName(string input, string expectedOutput)
     {
-        var actualOutput = PathHelpers.GetDirectoryName(input, CreateOSInformation(isUnix)).ToString();
+        var actualOutput = PathHelpers.GetDirectoryName(input).ToString();
         actualOutput.Should().Be(expectedOutput);
     }
 
     [Theory]
-    [InlineData(true, "", "", true)]
-    [InlineData(true, "foo", "", true)]
-    [InlineData(true, "", "foo", false)]
-    [InlineData(true, "foo/bar", "foo", true)]
-    [InlineData(true, "foo", "bar", false)]
-    [InlineData(true, "/", "/", true)]
-    [InlineData(true, "/foo", "/", true)]
-    [InlineData(true, "/foo/bar/baz", "/", true)]
-    [InlineData(true, "/foo/bar/baz", "/foo", true)]
-    [InlineData(true, "/foo/bar/baz", "/foo/bar", true)]
-    [InlineData(true, "/foobar", "/foo", false)]
-    [InlineData(false, "C:/", "C:/", true)]
-    [InlineData(false, "C:/foo", "C:/", true)]
-    [InlineData(false, "C:/foo/bar/baz", "C:/", true)]
-    [InlineData(false, "C:/foo/bar/baz", "C:/foo", true)]
-    [InlineData(false, "C:/foo/bar/baz", "C:/foo/bar", true)]
-    [InlineData(false, "C:/foobar", "C:/foo", false)]
-    public void Test_InFolder(bool isUnix, string child, string parent, bool expected)
+    [InlineData( "", "", true)]
+    [InlineData( "foo", "", true)]
+    [InlineData( "", "foo", false)]
+    [InlineData( "foo/bar", "foo", true)]
+    [InlineData( "foo", "bar", false)]
+    [InlineData( "/", "/", true)]
+    [InlineData( "/foo", "/", true)]
+    [InlineData( "/foo/bar/baz", "/", true)]
+    [InlineData( "/foo/bar/baz", "/foo", true)]
+    [InlineData( "/foo/bar/baz", "/foo/bar", true)]
+    [InlineData( "/foobar", "/foo", false)]
+    [InlineData( "C:/", "C:/", true)]
+    [InlineData( "C:/foo", "C:/", true)]
+    [InlineData( "C:/foo/bar/baz", "C:/", true)]
+    [InlineData( "C:/foo/bar/baz", "C:/foo", true)]
+    [InlineData( "C:/foo/bar/baz", "C:/foo/bar", true)]
+    [InlineData( "C:/foobar", "C:/foo", false)]
+    public void Test_InFolder(string child, string parent, bool expected)
     {
-        var actual = PathHelpers.InFolder(child, parent, CreateOSInformation(isUnix));
+        var actual = PathHelpers.InFolder(child, parent);
         actual.Should().Be(expected);
     }
 
     [Theory]
-    [InlineData(true, "", "", "")]
-    [InlineData(true, "foo/bar", "foo", "bar")]
-    [InlineData(true, "/foo", "/", "foo")]
-    [InlineData(true, "/foo/bar", "/foo", "bar")]
-    [InlineData(false, "C:/foo", "C:/", "foo")]
-    [InlineData(false, "C:/foo/bar", "C:/foo", "bar")]
-    public void Test_RelativeTo(bool isUnix, string child, string parent, string expectedOutput)
+    [InlineData( "", "", "")]
+    [InlineData( "foo/bar", "foo", "bar")]
+    [InlineData( "/foo", "/", "foo")]
+    [InlineData( "/foo/bar", "/foo", "bar")]
+    [InlineData( "C:/foo", "C:/", "foo")]
+    [InlineData( "C:/foo/bar", "C:/foo", "bar")]
+    public void Test_RelativeTo(string child, string parent, string expectedOutput)
     {
-        var actualOutput = PathHelpers.RelativeTo(child, parent, CreateOSInformation(isUnix)).ToString();
+        var actualOutput = PathHelpers.RelativeTo(child, parent).ToString();
         actualOutput.Should().Be(expectedOutput);
     }
 
     [Theory]
-    [InlineData(true, "", "")]
-    [InlineData(true, "/", "/")]
-    [InlineData(false, "C:/", "C:/")]
-    [InlineData(true, "foo/bar", "foo")]
-    [InlineData(true, "foo/bar/baz", "foo")]
-    public void Test_GetTopParent(bool isUnix, string path, string expectedOutput)
+    [InlineData( "", "")]
+    [InlineData( "/", "/")]
+    [InlineData( "C:/", "C:/")]
+    [InlineData( "foo/bar", "foo")]
+    [InlineData( "foo/bar/baz", "foo")]
+    public void Test_GetTopParent(string path, string expectedOutput)
     {
-        var actualOutput = PathHelpers.GetTopParent(path, CreateOSInformation(isUnix)).ToString();
+        var actualOutput = PathHelpers.GetTopParent(path).ToString();
         actualOutput.Should().Be(expectedOutput);
     }
 
     [Theory]
-    [InlineData(true, "", 0, "")]
-    [InlineData(true, "/", 0, "/")]
-    [InlineData(true, "/", 1, "")]
-    [InlineData(true, "/foo", 1, "foo")]
-    [InlineData(true, "/foo/bar", 1, "foo/bar")]
-    [InlineData(true, "/foo/bar", 2, "bar")]
-    [InlineData(true, "/foo/bar", 3, "")]
-    [InlineData(false, "C:/", 0, "C:/")]
-    [InlineData(false, "C:/", 1, "")]
-    [InlineData(false, "C:/foo", 1, "foo")]
-    [InlineData(false, "C:/foo/bar", 1, "foo/bar")]
-    [InlineData(false, "C:/foo/bar", 2, "bar")]
-    [InlineData(false, "C:/foo/bar", 3, "")]
-    public void Test_DropParents(bool isUnix, string path, int count, string expectedOutput)
+    [InlineData("", 0, "")]
+    [InlineData("/", 0, "/")]
+    [InlineData("/", 1, "")]
+    [InlineData("/foo", 1, "foo")]
+    [InlineData("/foo/bar", 1, "foo/bar")]
+    [InlineData("/foo/bar", 2, "bar")]
+    [InlineData("/foo/bar", 3, "")]
+    [InlineData("C:/", 0, "C:/")]
+    [InlineData("C:/", 1, "")]
+    [InlineData("C:/foo", 1, "foo")]
+    [InlineData("C:/foo/bar", 1, "foo/bar")]
+    [InlineData("C:/foo/bar", 2, "bar")]
+    [InlineData("C:/foo/bar", 3, "")]
+    [InlineData("//Server/foo/bar", 2, "bar")]
+    [InlineData("//./C:/foo/bar", 2, "bar")]
+    public void Test_DropParents(string path, int count, string expectedOutput)
     {
-        var actualOutput = PathHelpers.DropParents(path, count, CreateOSInformation(isUnix)).ToString();
+        var actualOutput = PathHelpers.DropParents(path, count).ToString();
         actualOutput.Should().Be(expectedOutput);
     }
 
     [Theory]
-    [InlineData(true, false, "", "")]
-    [InlineData(true, false, "foo/bar", "foo+bar")]
-    [InlineData(true, false,"/", "/")]
-    [InlineData(true, false,"/foo", "/+foo")]
-    [InlineData(true, false,"/foo/bar/baz", "/+foo+bar+baz")]
-    [InlineData(false, false,"C:/", "C:/")]
-    [InlineData(false, false,"C:/foo", "C:/+foo")]
-    [InlineData(false, false,"C:/foo/bar/baz", "C:/+foo+bar+baz")]
-    [InlineData(true, true, "", "")]
-    [InlineData(true, true, "foo/bar", "bar+foo")]
-    [InlineData(true, true,"/", "/")]
-    [InlineData(true, true,"/foo", "foo+/")]
-    [InlineData(true, true,"/foo/bar/baz", "baz+bar+foo+/")]
-    [InlineData(false, true,"C:/", "C:/")]
-    [InlineData(false, true,"C:/foo", "foo+C:/")]
-    [InlineData(false, true,"C:/foo/bar/baz", "baz+bar+foo+C:/")]
-    public void Test_WalkParts(bool isUnix, bool isReverse, string path, string expectedOutput)
+    [InlineData( false, "", "")]
+    [InlineData( false, "foo/bar", "foo+bar")]
+    [InlineData( false,"/", "/")]
+    [InlineData( false,"/foo", "/+foo")]
+    [InlineData( false,"/foo/bar/baz", "/+foo+bar+baz")]
+    [InlineData( false,"C:/", "C:/")]
+    [InlineData( false,"C:/foo", "C:/+foo")]
+    [InlineData( false,"C:/foo/bar/baz", "C:/+foo+bar+baz")]
+    [InlineData( true, "", "")]
+    [InlineData( true, "foo/bar", "bar+foo")]
+    [InlineData( true,"/", "/")]
+    [InlineData( true,"/foo", "foo+/")]
+    [InlineData( true,"/foo/bar/baz", "baz+bar+foo+/")]
+    [InlineData( true,"C:/", "C:/")]
+    [InlineData( true,"C:/foo", "foo+C:/")]
+    [InlineData( true,"C:/foo/bar/baz", "baz+bar+foo+C:/")]
+    public void Test_WalkParts(bool isReverse, string path, string expectedOutput)
     {
         var sb = new StringBuilder();
 
@@ -489,7 +457,7 @@ public class PathHelperTests
             if (sb_.Length != 0) sb_.Append('+');
             sb_.Append(part);
             return true;
-        }, CreateOSInformation(isUnix), isReverse);
+        }, isReverse);
 
         var actualOutput = sb.ToString();
         actualOutput.Should().Be(expectedOutput);
@@ -500,30 +468,30 @@ public class PathHelperTests
             if (sb.Length != 0) sb.Append('+');
             sb.Append(part);
             return true;
-        }, CreateOSInformation(isUnix), isReverse);
+        }, isReverse);
 
         actualOutput = sb.ToString();
         actualOutput.Should().Be(expectedOutput);
     }
 
     [Theory]
-    [InlineData(true, false, "/foo/bar/baz", 1, "/")]
-    [InlineData(true, false, "/foo/bar/baz", 2, "/+foo")]
-    [InlineData(true, false, "/foo/bar/baz", 3, "/+foo+bar")]
-    [InlineData(true, false, "/foo/bar/baz", 4, "/+foo+bar+baz")]
-    [InlineData(true, true, "/foo/bar/baz", 1, "baz")]
-    [InlineData(true, true, "/foo/bar/baz", 2, "baz+bar")]
-    [InlineData(true, true, "/foo/bar/baz", 3, "baz+bar+foo")]
-    [InlineData(true, true, "/foo/bar/baz", 4, "baz+bar+foo+/")]
-    [InlineData(false, false, "C:/foo/bar/baz", 1, "C:/")]
-    [InlineData(false, false, "C:/foo/bar/baz", 2, "C:/+foo")]
-    [InlineData(false, false, "C:/foo/bar/baz", 3, "C:/+foo+bar")]
-    [InlineData(false, false, "C:/foo/bar/baz", 4, "C:/+foo+bar+baz")]
-    [InlineData(false, true, "C:/foo/bar/baz", 1, "baz")]
-    [InlineData(false, true, "C:/foo/bar/baz", 2, "baz+bar")]
-    [InlineData(false, true, "C:/foo/bar/baz", 3, "baz+bar+foo")]
-    [InlineData(false, true, "C:/foo/bar/baz", 4, "baz+bar+foo+C:/")]
-    public void Test_WalkPartsPartially(bool isUnix, bool isReverse, string path, int stopAfterN, string expectedOutput)
+    [InlineData( false, "/foo/bar/baz", 1, "/")]
+    [InlineData( false, "/foo/bar/baz", 2, "/+foo")]
+    [InlineData( false, "/foo/bar/baz", 3, "/+foo+bar")]
+    [InlineData( false, "/foo/bar/baz", 4, "/+foo+bar+baz")]
+    [InlineData( true, "/foo/bar/baz", 1, "baz")]
+    [InlineData( true, "/foo/bar/baz", 2, "baz+bar")]
+    [InlineData( true, "/foo/bar/baz", 3, "baz+bar+foo")]
+    [InlineData( true, "/foo/bar/baz", 4, "baz+bar+foo+/")]
+    [InlineData( false, "C:/foo/bar/baz", 1, "C:/")]
+    [InlineData( false, "C:/foo/bar/baz", 2, "C:/+foo")]
+    [InlineData( false, "C:/foo/bar/baz", 3, "C:/+foo+bar")]
+    [InlineData( false, "C:/foo/bar/baz", 4, "C:/+foo+bar+baz")]
+    [InlineData( true, "C:/foo/bar/baz", 1, "baz")]
+    [InlineData( true, "C:/foo/bar/baz", 2, "baz+bar")]
+    [InlineData( true, "C:/foo/bar/baz", 3, "baz+bar+foo")]
+    [InlineData( true, "C:/foo/bar/baz", 4, "baz+bar+foo+C:/")]
+    public void Test_WalkPartsPartially(bool isReverse, string path, int stopAfterN, string expectedOutput)
     {
         var sb = new StringBuilder();
         var counter = 0;
@@ -534,7 +502,7 @@ public class PathHelperTests
             sb.Append(part);
             counter++;
             return counter < stopAfterN;
-        }, CreateOSInformation(isUnix), isReverse);
+        }, isReverse);
 
         var actualOutput = sb.ToString();
         actualOutput.Should().Be(expectedOutput);
@@ -542,18 +510,18 @@ public class PathHelperTests
 
     [Theory]
     [MemberData(nameof(TestData_GetParts))]
-    public void Test_GetParts(bool isUnix, bool isReverse, string path, List<string> expectedOutput)
+    public void Test_GetParts(bool isReverse, string path, List<string> expectedOutput)
     {
-        var actualOutput = PathHelpers.GetParts(path, CreateOSInformation(isUnix), isReverse);
+        var actualOutput = PathHelpers.GetParts(path, isReverse);
         actualOutput.Should().Equal(expectedOutput);
     }
 
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     public static IEnumerable<object[]> TestData_GetParts => new[]
     {
-        new object[] { true, false, "/foo/bar/baz", new List<string> { "/", "foo", "bar", "baz" } },
-        new object[] { true, true, "/foo/bar/baz", new List<string> { "baz", "bar", "foo", "/" } },
-        new object[] { false, false, "C:/foo/bar/baz", new List<string>{ "C:/", "foo", "bar", "baz" }},
-        new object[] { false, true, "C:/foo/bar/baz", new List<string>{ "baz", "bar", "foo", "C:/" }},
+        new object[] { false, "/foo/bar/baz", new List<string> { "/", "foo", "bar", "baz" } },
+        new object[] { true, "/foo/bar/baz", new List<string> { "baz", "bar", "foo", "/" } },
+        new object[] { false, "C:/foo/bar/baz", new List<string>{ "C:/", "foo", "bar", "baz" }},
+        new object[] { true, "C:/foo/bar/baz", new List<string>{ "baz", "bar", "foo", "C:/" }},
     };
 }

--- a/tests/NexusMods.Paths.Tests/RelativePathTests.cs
+++ b/tests/NexusMods.Paths.Tests/RelativePathTests.cs
@@ -32,7 +32,6 @@ public class RelativePathTests
         path.ToString().Should().Be(expected);
     }
 
-
     [Theory]
     [InlineData("a", "a")]
     [InlineData("a/", "a")]


### PR DESCRIPTION
This PR undoes an API design decision I made in https://github.com/Nexus-Mods/NexusMods.App/pull/345. Almost all methods in `PathHelper` have `IOSInformation` as an argument, even if they don't use it in release mode. Many methods just needed it for the debug assertion that the input is sanitized. The only method that actually needed `IOSInformation` was the `GetRootLength` method which checked whether the provided OS was a Unix-style OS or Window.

Needing to pass in `IOSInformation` to everything made the API quite cumbersome and annoying to test. There were also issues when dealing with cross-platform paths in situations where you had a Linux host dealing with Windows paths in a WINE prefix.

The system would break down if you say "this path is a Linux path" and provide a Windows path or vise-versa. Instead of having the API consumer tell us what kind of path we have, we can just check and verify.

This PR adds a new method to parse out the root type, something we should've had earlier. I've also deprecated the old API methods and added new ones so that upgrading will be slightly easier.

Finally, a quick note about the new method, I did add new root types we previously didn't bother with like UNC and DOS device paths. It's very unlikely we'll ever see them in the wild, but our system should work just fine as-is without any additional changes needed to accommodate them.