### PR TITLE
Fix `GetHashCode` weirdness for paths

### DIFF
--- a/src/NexusMods.Paths/AbsolutePath.cs
+++ b/src/NexusMods.Paths/AbsolutePath.cs
@@ -352,11 +352,10 @@ public readonly partial struct AbsolutePath : IEquatable<AbsolutePath>, IPath<Ab
     /// <inheritdoc />
     public override int GetHashCode()
     {
-        // A custom HashCode, based on FNV-1 with added Vectorization because the default one is very slow for our use in trees, dictionaries, etc.
-        // .NET does have a faster hashcode for strings, however it is not exposed (and is 5x slower than custom one anyways).
-        var a = Directory.GetHashCodeLowerFast();
-        var b = FileName.GetHashCodeLowerFast();
+        var a = PathHelpers.PathHashCode(Directory);
+        var b = PathHelpers.PathHashCode(FileName);
         return HashCode.Combine(a, b);
     }
+
     #endregion
 }

--- a/src/NexusMods.Paths/RelativePath.cs
+++ b/src/NexusMods.Paths/RelativePath.cs
@@ -326,9 +326,7 @@ public readonly struct RelativePath : IPath<RelativePath>, IEquatable<RelativePa
     /// <inheritdoc />
     public override int GetHashCode()
     {
-        // A custom HashCode, based on FNV-1 with added Vectorization because the default one is very slow for our use in trees, dictionaries, etc.
-        // .NET does have a faster hashcode for strings, however it is not exposed (and is 5x slower than custom one anyways).
-        return Path.GetHashCodeLowerFast().GetHashCode();
+        return PathHelpers.PathHashCode(Path);
     }
 
     #endregion

--- a/src/NexusMods.Paths/Utilities/PathHelpers.cs
+++ b/src/NexusMods.Paths/Utilities/PathHelpers.cs
@@ -334,6 +334,16 @@ public static class PathHelpers
     }
 
     /// <summary>
+    /// Returns the hash code of the input path.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int PathHashCode(string input)
+    {
+        DebugAssertIsSanitized(input);
+        return StringComparer.OrdinalIgnoreCase.GetHashCode(input);
+    }
+
+    /// <summary>
     /// Returns true if the given character is a valid Windows drive letter.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
We've observed weird hash code behaviors in the app for relative paths which were using custom code before. This PR updates the `GetHashCode` methods to use the built-in string `GetHashCode` method.